### PR TITLE
Add eigen_mav_msgs dependency to header.

### DIFF
--- a/mav_trajectory_generation_ros/include/mav_trajectory_generation_ros/ros_visualization.h
+++ b/mav_trajectory_generation_ros/include/mav_trajectory_generation_ros/ros_visualization.h
@@ -23,6 +23,7 @@
 
 #include <mav_visualization/marker_group.h>
 #include <visualization_msgs/MarkerArray.h>
+#include <mav_msgs/eigen_mav_msgs.h>
 
 #include <mav_trajectory_generation/trajectory.h>
 #include <mav_trajectory_generation/vertex.h>


### PR DESCRIPTION
No idea why jenkins let this pass in https://github.com/ethz-asl/mav_trajectory_generation/pull/6, but did not let it pass in https://github.com/ethz-asl/mav_pathplanning/pull/177 .