### PR TITLE
Fix crash on vis in waypoint navigator.

### DIFF
--- a/mav_trajectory_generation/src/segment.cpp
+++ b/mav_trajectory_generation/src/segment.cpp
@@ -34,6 +34,7 @@ const Polynomial& Segment::operator[](size_t idx) const {
 
 Eigen::VectorXd Segment::evaluate(double t, int derivative) const {
   Eigen::VectorXd result(D_);
+  result.setZero();
   for (int d = 0; d < D_; ++d) {
     result[d] = polynomials_[d].evaluate(t, derivative);
   }

--- a/mav_trajectory_generation/src/trajectory.cpp
+++ b/mav_trajectory_generation/src/trajectory.cpp
@@ -97,6 +97,7 @@ void Trajectory::evaluateRange(double t_start, double t_end, double dt,
       if (i >= segments_.size()) {
         break;
       }
+      continue;
     }
 
     result->push_back(segments_[i].evaluate(time_in_segment, derivative_order));
@@ -140,7 +141,7 @@ Trajectory Trajectory::getTrajectoryWithAppendedDimension(
   CHECK_EQ(N_, trajectory_to_append.N());
   CHECK_EQ(static_cast<int>(segments_.size()), trajectory_to_append.K());
 
-  // Create a new set of segments with just 1 dimension.
+  // Create a new set of segments with all of the dimensions.
   Segment::Vector segments;
   segments.reserve(segments_.size());
 

--- a/mav_trajectory_generation_ros/src/ros_visualization.cpp
+++ b/mav_trajectory_generation_ros/src/ros_visualization.cpp
@@ -35,7 +35,7 @@ void appendMarkers(const visualization_msgs::MarkerArray& markers_to_insert,
                    visualization_msgs::MarkerArray* marker_array) {
   marker_array->markers.reserve(marker_array->markers.size() +
                                 markers_to_insert.markers.size());
-  for (const auto marker : markers_to_insert.markers) {
+  for (const visualization_msgs::Marker& marker : markers_to_insert.markers) {
     marker_array->markers.push_back(marker);
     if (!marker_namespace.empty()) {
       marker_array->markers.back().ns = marker_namespace;
@@ -87,6 +87,7 @@ void drawMavTrajectoryWithMavMarker(
     visualization_msgs::MarkerArray* marker_array) {
   // Sample the trajectory.
   mav_msgs::EigenTrajectoryPoint::Vector flat_states;
+
   bool success =
       sampleWholeTrajectory(trajectory, kDefaultSamplingTime, &flat_states);
   if (!success) {
@@ -111,7 +112,7 @@ void drawMavSampledTrajectoryWithMavMarker(
   line_strip.scale.x = 0.01;
   line_strip.ns = "path";
 
-  double accumulated_distance = 0;
+  double accumulated_distance = 0.0;
   Eigen::Vector3d last_position = Eigen::Vector3d::Zero();
   for (size_t i = 0; i < flat_states.size(); ++i) {
     const mav_msgs::EigenTrajectoryPoint& flat_state = flat_states[i];

--- a/mav_visualization/include/mav_visualization/helpers.h
+++ b/mav_visualization/include/mav_visualization/helpers.h
@@ -135,7 +135,7 @@ void drawArrowPoints(const Eigen::Vector3d& p1, const Eigen::Vector3d& p2,
 void drawAxesArrows(const Eigen::Vector3d& p, const Eigen::Quaterniond& q,
                     double scale, double diameter,
                     visualization_msgs::MarkerArray* marker_array) {
-  const double alpha = 1;
+  const double alpha = 1.0;
   marker_array->markers.resize(3);
   Eigen::Vector3d origin;
   origin.setZero();


### PR DESCRIPTION
Issue was with segments having a time allocation of < dt (which we *shouldn't do* for numerical issues), as they will still get sampled but at dt rather than whatever tiny time allocation they have. Plus one or two trivial cleanups.

Output of visualization now:
![fixed_viz](https://cloud.githubusercontent.com/assets/5616392/25335631/2695c05a-28f4-11e7-91cb-6e332e364d34.png)

(Partially) resolves #13 