### PR TITLE
Feature/separate input constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,13 +320,14 @@ time, no false positives).
 ###Example
 ```c++
 // Create input constraints.
+typedef InputConstraintType ICT;
 InputConstraints input_constraints;
-input_constraints.setFMin(0.5 * 9.81); // minimum acceleration in [m/s/s].
-input_constraints.setFMax(1.5 * 9.81); // maximum acceleration in [m/s/s].
-input_constraints.setVMax(3.5); // maximum velocity in [m/s].
-input_constraints.setOmegaXYMax(M_PI / 2.0); // maximum roll/pitch rates in [rad/s].
-input_constraints.setOmegaZMax(M_PI / 2.0); // maximum yaw rates in [rad/s].
-input_constraints.setOmegaZDotMax(M_PI); // maximum yaw acceleration in [rad/s/s].
+input_constraints.addConstraint(ICT::kFMin, 0.5 * 9.81); // minimum acceleration in [m/s/s].
+input_constraints.addConstraint(ICT::kFMax, 1.5 * 9.81); // maximum acceleration in [m/s/s].
+input_constraints.addConstraint(ICT::kVMax, 3.5); // maximum velocity in [m/s].
+input_constraints.addConstraint(ICT::kOmegaXYMax, M_PI / 2.0); // maximum roll/pitch rates in [rad/s].
+input_constraints.addConstraint(ICT::kOmegaZMax, M_PI / 2.0); // maximum yaw rates in [rad/s].
+input_constraints.addConstraint(ICT::kOmegaZDotMax, M_PI); // maximum yaw acceleration in [rad/s/s].
 
 // Create feasibility object of choice (FeasibilityAnalytic,
 // FeasibilitySampling, FeasibilityRecursive).

--- a/mav_trajectory_generation/src/vertex.cpp
+++ b/mav_trajectory_generation/src/vertex.cpp
@@ -93,7 +93,7 @@ void Vertex::addConstraint(int derivative_order,
 }
 
 bool Vertex::removeConstraint(int type) {
-  Constraints::iterator it = constraints_.find(type);
+  Constraints::const_iterator it = constraints_.find(type);
   if (it != constraints_.end()) {
     constraints_.erase(it);
     return true;

--- a/mav_trajectory_generation_ros/CMakeLists.txt
+++ b/mav_trajectory_generation_ros/CMakeLists.txt
@@ -15,6 +15,7 @@ cs_add_library(${PROJECT_NAME}
   src/feasibility_base.cpp
   src/feasibility_recursive.cpp
   src/feasibility_sampling.cpp
+  src/input_constraints.cpp
   src/ros_conversions.cpp
   src/ros_visualization.cpp
   src/trajectory_sampling.cpp

--- a/mav_trajectory_generation_ros/include/mav_trajectory_generation_ros/feasibility_base.h
+++ b/mav_trajectory_generation_ros/include/mav_trajectory_generation_ros/feasibility_base.h
@@ -28,6 +28,8 @@
 
 #include <mav_trajectory_generation/trajectory.h>
 
+#include "input_constraints.h"
+
 namespace mav_trajectory_generation {
 enum InputFeasibilityResult {
   kInputFeasible = 0,    // The trajectory is input feasible.
@@ -49,47 +51,6 @@ enum InputFeasibilityResult {
 
 // Human readable InputFeasibilityResult.
 std::string getInputFeasibilityResultName(InputFeasibilityResult fr);
-
-// Dynamic constraints of the MAV.
-class InputConstraints {
- public:
-  // Reasonable default constraints.
-  InputConstraints();
-  InputConstraints(double f_min, double f_max, double v_max,
-                   double omega_xy_max, double omega_z_max,
-                   double omega_z_dot_max);
-  // Needs to be smaller than f_max_. Otherwise f_max_ will be set f_min.
-  void setFMin(double f_min);
-  // Needs to be larger than f_min_. Otherwise f_min_ will be set f_max.
-  void setFMax(double f_max);
-  void setVMax(double v_max);
-  void setOmegaXYMax(double omega_xy_max);
-  void setOmegaZMax(double omega_z_max);
-  void setOmegaZDotMax(double omega_z_dot_max);
-  // Sets all constraints to reasonable default values.
-  void setDefaultValues();
-
-  inline double getFMin() const { return f_min_; }
-  inline double getFMax() const { return f_max_; }
-  inline double getVMax() const { return v_max_; }
-  inline double getOmegaXYMax() const { return omega_xy_max_; }
-  inline double getOmegaZMax() const { return omega_z_max_; }
-  inline double getOmegaZDotMax() const { return omega_z_dot_max_; }
-
- private:
-  // Minimum input acceleration (mass normalized thrust) [m/s/s].
-  double f_min_;
-  // Maximum input acceleration (mass normalized thrust) [m/s/s].
-  double f_max_;
-  // Maximum velocity [m/s].
-  double v_max_;
-  // Maximum roll/pitch input rate [rad/s].
-  double omega_xy_max_;
-  // Maximum yaw rate [rad/s].
-  double omega_z_max_;
-  // Maximum yaw acc [rad/s^2].
-  double omega_z_dot_max_;
-};
 
 // A half plane is defined through a point and a normal.
 class HalfPlane {

--- a/mav_trajectory_generation_ros/include/mav_trajectory_generation_ros/input_constraints.h
+++ b/mav_trajectory_generation_ros/include/mav_trajectory_generation_ros/input_constraints.h
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-<map>
+#include <map>
 
 namespace mav_trajectory_generation {
 

--- a/mav_trajectory_generation_ros/include/mav_trajectory_generation_ros/input_constraints.h
+++ b/mav_trajectory_generation_ros/include/mav_trajectory_generation_ros/input_constraints.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2016, Markus Achtelik, ASL, ETH Zurich, Switzerland
+ * Copyright (c) 2016, Michael Burri, ASL, ETH Zurich, Switzerland
+ * Copyright (c) 2016, Helen Oleynikova, ASL, ETH Zurich, Switzerland
+ * Copyright (c) 2016, Rik Bähnemann, ASL, ETH Zurich, Switzerland
+ * Copyright (c) 2016, Marija Popovic, ASL, ETH Zurich, Switzerland
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+<map>
+
+namespace mav_trajectory_generation {
+
+enum InputConstraintType {
+  kFMin = 0,    // Minimum acceleration (normalized thrust) in [m/s/s].
+  kFMax,  // Maximum acceleration (normalized thrust) in [m/s/s].
+  kVMax,      // Maximum velocity in [m/s].
+  kOmegaXYMax,       // Maximum roll/pitch rate in [rad/s].
+  kOmegaZMax, // Maximum yaw rate in [rad/s].
+  kOmegaZDotMax // Maximum yaw acceleration in [rad/s/s].
+};
+
+// Dynamic constraints of the MAV.
+class InputConstraints {
+ public:
+  // Empty constraints object.
+  InputConstraints() {}
+
+  // Set a constraint given type and value.
+  void addConstraint(int constraint_type, double value);
+
+  // Sets all constraints to reasonable default values.
+  void setDefaultValues();
+
+  // Return a constraint. Returns false if constraint is not set.
+  bool getConstraint(int constraint_type, double* value) const;
+
+  // Check if a specific constraint type is set.
+  bool hasConstraint(int constraint_type) const;
+
+  // Remove a specific constraint type. Returns false if constraint was not set.
+  bool removeConstraint(int constraint_type);
+
+ private:
+  std::map<int, double> constraints_;
+};
+}  // namespace mav_trajectory_generation

--- a/mav_trajectory_generation_ros/src/feasibility_analytic.cpp
+++ b/mav_trajectory_generation_ros/src/feasibility_analytic.cpp
@@ -45,67 +45,86 @@ InputFeasibilityResult FeasibilityAnalytic::checkInputFeasibility(
   }
   // Check constraints.
   // Thrust:
-  std::vector<Extremum> thrust_candidates;
-  Segment thrust_segment(segment.N() - 2, kPosDim.size());
-  InputFeasibilityResult thrust_result =
-      analyticThrustFeasibility(segment, &thrust_candidates, &thrust_segment);
-  if (thrust_result != InputFeasibilityResult::kInputFeasible) {
-    return thrust_result;
+  if (input_constraints_.hasConstraint(InputConstraintType::kFMin ||
+                                       InputConstraintType::kFMax ||
+                                       InputConstraintType::kOmegaXYMax)) {
+    std::vector<Extremum> thrust_candidates;
+    Segment thrust_segment(segment.N() - 2, kPosDim.size());
+    InputFeasibilityResult thrust_result =
+        analyticThrustFeasibility(segment, &thrust_candidates, &thrust_segment);
+    if (thrust_result != InputFeasibilityResult::kInputFeasible) {
+      return thrust_result;
+    }
   }
 
   // Velocity:
-  std::vector<Extremum> velocity_candidates;
-  if (!segment.computeMinMaxMagnitudeCandidates(derivative_order::VELOCITY, 0.0,
-                                                segment.getTime(), kPosDim,
-                                                &velocity_candidates)) {
-    return InputFeasibilityResult::kInputIndeterminable;
-  }
-  const double v_max =
-      std::max_element(velocity_candidates.begin(), velocity_candidates.end())
-          ->value;
-  if (v_max > input_constraints_.getVMax()) {
-    return InputFeasibilityResult::kInputInfeasibleVelocity;
+  double v_max_limit;
+  if (input_constraints_.getConstraint(InputConstraintType::kVMax,
+                                       &v_max_limit)) {
+    std::vector<Extremum> velocity_candidates;
+    if (!segment.computeMinMaxMagnitudeCandidates(
+            derivative_order::VELOCITY, 0.0, segment.getTime(), kPosDim,
+            &velocity_candidates)) {
+      return InputFeasibilityResult::kInputIndeterminable;
+    }
+    const double v_max =
+        std::max_element(velocity_candidates.begin(), velocity_candidates.end())
+            ->value;
+    if (v_max > v_max_limit) {
+      return InputFeasibilityResult::kInputInfeasibleVelocity;
+    }
   }
 
   // Yaw feasibility (assumed independent of translation in the rigid body
   // model)
   if (segment.D() == 4) {
     // Check the single axis minimum / maximum yaw rate:
-    std::pair<double, double> yaw_rate_min, yaw_rate_max;
-    if (!segment[3].computeMinMax(0.0, segment.getTime(),
-                                  derivative_order::ANGULAR_VELOCITY,
-                                  &yaw_rate_min, &yaw_rate_max)) {
-      return InputFeasibilityResult::kInputIndeterminable;
+    double yaw_rate_limit;
+    if (input_constraints_.getConstraint(InputConstraintType::kOmegaZMax,
+                                         &yaw_rate_limit)) {
+      std::pair<double, double> yaw_rate_min, yaw_rate_max;
+      if (!segment[3].computeMinMax(0.0, segment.getTime(),
+                                    derivative_order::ANGULAR_VELOCITY,
+                                    &yaw_rate_min, &yaw_rate_max)) {
+        return InputFeasibilityResult::kInputIndeterminable;
+      }
+      if (std::max(std::abs(yaw_rate_min.second),
+                   std::abs(yaw_rate_max.second)) > yaw_rate_limit) {
+        return InputFeasibilityResult::kInputInfeasibleYawRates;
+      }
     }
-    if (std::max(std::abs(yaw_rate_min.second), std::abs(yaw_rate_max.second)) >
-        input_constraints_.getOmegaZMax()) {
-      return InputFeasibilityResult::kInputInfeasibleYawRates;
-    }
+
     // Check the single axis minimum / maximum yaw acceleration:
-    std::pair<double, double> yaw_acc_min, yaw_acc_max;
-    if (!segment[3].computeMinMax(0.0, segment.getTime(),
-                                  derivative_order::ANGULAR_ACCELERATION,
-                                  &yaw_acc_min, &yaw_acc_max)) {
-      return InputFeasibilityResult::kInputIndeterminable;
-    }
-    if (std::max(std::abs(yaw_acc_min.second), std::abs(yaw_acc_max.second)) >
-        input_constraints_.getOmegaZDotMax()) {
-      return InputFeasibilityResult::kInputInfeasibleYawAcc;
+    double yaw_acc_limit;
+    if (input_constraints_.getConstraint(InputConstraintType::kOmegaZDotMax,
+                                         &yaw_acc_limit)) {
+      std::pair<double, double> yaw_acc_min, yaw_acc_max;
+      if (!segment[3].computeMinMax(0.0, segment.getTime(),
+                                    derivative_order::ANGULAR_ACCELERATION,
+                                    &yaw_acc_min, &yaw_acc_max)) {
+        return InputFeasibilityResult::kInputIndeterminable;
+      }
+      if (std::max(std::abs(yaw_acc_min.second), std::abs(yaw_acc_max.second)) >
+          yaw_acc_limit) {
+        return InputFeasibilityResult::kInputInfeasibleYawAcc;
+      }
     }
   }
 
   // Roll / Pitch rates using recursive test:
-  std::vector<Extremum> jerk_candidates;
-  if (!segment.computeMinMaxMagnitudeCandidates(derivative_order::JERK, 0.0,
-                                                segment.getTime(), kPosDim,
-                                                &jerk_candidates)) {
-    return InputFeasibilityResult::kInputIndeterminable;
-  }
-  InputFeasibilityResult omega_xy_result =
-      recursiveRollPitchFeasibility(segment, thrust_segment, thrust_candidates,
-                                    jerk_candidates, 0.0, segment.getTime());
-  if (omega_xy_result != InputFeasibilityResult::kInputFeasible) {
-    return omega_xy_result;
+  if (input_constraints_.hasConstraint(InputConstraintType::kOmegaXYMax)) {
+    std::vector<Extremum> jerk_candidates;
+    if (!segment.computeMinMaxMagnitudeCandidates(derivative_order::JERK, 0.0,
+                                                  segment.getTime(), kPosDim,
+                                                  &jerk_candidates)) {
+      return InputFeasibilityResult::kInputIndeterminable;
+    }
+    InputFeasibilityResult omega_xy_result = recursiveRollPitchFeasibility(
+        segment, thrust_segment, thrust_candidates, jerk_candidates, 0.0,
+        segment.getTime());
+    if (omega_xy_result != InputFeasibilityResult::kInputFeasible) {
+      return omega_xy_result;
+    }
   }
 
   return InputFeasibilityResult::kInputFeasible;
@@ -131,19 +150,28 @@ InputFeasibilityResult FeasibilityAnalytic::analyticThrustFeasibility(
           0, 0.0, thrust_segment->getTime(), kPosDim, thrust_candidates)) {
     return InputFeasibilityResult::kInputIndeterminable;
   }
+
   // Evaluate the candidates.
-  const double f_min =
-      std::min_element(thrust_candidates->begin(), thrust_candidates->end())
-          ->value;
-  const double f_max =
-      std::max_element(thrust_candidates->begin(), thrust_candidates->end())
-          ->value;
-  if (f_max > input_constraints_.getFMax()) {
-    return InputFeasibilityResult::kInputInfeasibleThrustHigh;
-  }
-  if (f_min < input_constraints_.getFMin()) {
-    return InputFeasibilityResult::kInputInfeasibleThrustLow;
-  }
+  double f_min_constraint;
+  if (input_constraints_.getConstraint(InputConstraintType::kFMin,
+                                       &f_min_constraint) {
+    const double f_min =
+        std::min_element(thrust_candidates->begin(), thrust_candidates->end())
+            ->value;
+    if (f_min < f_min_constraint) {
+      return InputFeasibilityResult::kInputInfeasibleThrustLow;
+    }
+ }
+
+ double f_max_constraint;
+ if(input_constraints_.getConstraint(InputConstraintType::kFMax, &f_max_constraint)) {
+    const double f_max =
+        std::max_element(thrust_candidates->begin(), thrust_candidates->end())
+            ->value;
+    if (f_max > f_max_constraint) {
+      return InputFeasibilityResult::kInputInfeasibleThrustHigh;
+    }
+ }
 
   return InputFeasibilityResult::kInputFeasible;
 }
@@ -179,7 +207,13 @@ InputFeasibilityResult FeasibilityAnalytic::recursiveRollPitchFeasibility(
   }
 
   // Possible infeasible.
-  if (omega_xy_upper_bound > input_constraints_.getOmegaXYMax()) {
+  double limit;
+  if (!input_constraints_.getConstraint(InputConstraintType::kOmegaXYMax,
+                                        &limit)) {
+    return InputFeasibilityResult::kInputFeasible;
+  }
+
+  if (omega_xy_upper_bound > limit) {
     // Indeterminate. Must check more closely:
     double t_half = (t_1 + t_2) / 2;
     InputFeasibilityResult result_1 = recursiveRollPitchFeasibility(

--- a/mav_trajectory_generation_ros/src/feasibility_base.cpp
+++ b/mav_trajectory_generation_ros/src/feasibility_base.cpp
@@ -51,56 +51,6 @@ std::string getInputFeasibilityResultName(InputFeasibilityResult fr) {
   return "Unknown!";
 }
 
-InputConstraints::InputConstraints()
-    : f_min_(0.0),
-      f_max_(std::numeric_limits<double>::max()),
-      v_max_(std::numeric_limits<double>::max()),
-      omega_xy_max_(std::numeric_limits<double>::max()),
-      omega_z_max_(std::numeric_limits<double>::max()),
-      omega_z_dot_max_(std::numeric_limits<double>::max()) {}
-
-InputConstraints::InputConstraints(double f_min, double f_max, double v_max,
-                                   double omega_xy_max, double omega_z_max,
-                                   double omega_z_dot_max) {
-setFMin(f_min);
-setFMax(f_max);
-setVMax(v_max);
-setOmegaXYMax(omega_xy_max);
-setOmegaZMax(omega_z_max);
-setOmegaZDotMax(omega_z_dot_max);
-}
-
-void InputConstraints::setFMin(double f_min) {
-  f_min = std::abs(f_min);
-  f_max_ = f_min > f_max_ ? f_min : f_max_;
-  f_min_ = f_min;
-}
-
-void InputConstraints::setFMax(double f_max) {
-  f_max = std::abs(f_max);
-  f_min_ = f_max < f_min_ ? f_max : f_min_;
-  f_max_ = f_max;
-}
-
-void InputConstraints::setVMax(double v_max) { v_max_ = std::abs(v_max); }
-void InputConstraints::setOmegaXYMax(double omega_xy_max) {
-  omega_xy_max_ = std::abs(omega_xy_max);
-}
-void InputConstraints::setOmegaZMax(double omega_z_max) {
-  omega_z_max_ = std::abs(omega_z_max);
-}
-void InputConstraints::setOmegaZDotMax(double omega_z_dot_max) {
-  omega_z_dot_max_ = std::abs(omega_z_dot_max);
-}
-void InputConstraints::setDefaultValues() {
-  setFMin(0.5 * mav_msgs::kGravity);
-  setFMax(1.5 * mav_msgs::kGravity);
-  setVMax(3.0);
-  setOmegaXYMax(M_PI / 2.0);
-  setOmegaZMax(M_PI / 2.0);
-  setOmegaZDotMax(2.0 * M_PI);
-}
-
 HalfPlane::HalfPlane(const Eigen::Vector3d& point,
                      const Eigen::Vector3d& normal)
     : point_(point), normal_(normal) {

--- a/mav_trajectory_generation_ros/src/feasibility_recursive.cpp
+++ b/mav_trajectory_generation_ros/src/feasibility_recursive.cpp
@@ -48,29 +48,38 @@ InputFeasibilityResult FeasibilityRecursive::checkInputFeasibility(
 
   // Find roots to determine single axis minima / maxima:
   Roots roots_acc, roots_jerk, roots_snap;
-  roots_acc.resize(3);
-  roots_jerk.resize(3);
-  roots_snap.resize(3);
-  for (size_t i = 0; i < 3; i++) {
-    // Can not find roots for zero and one coefficient. Min/max lie on interval
-    // border.
-    if (segment.N() - derivative_order::ACCELERATION > 1 &&
-        !findRootsJenkinsTraub(
-            segment[i].getCoefficients(derivative_order::ACCELERATION),
-            &roots_acc[i])) {
-      return InputFeasibilityResult::kInputIndeterminable;
+  if (input_constraints_.hasConstraint(InputConstraintType::kVMax)) {
+    roots_acc.resize(3);
+    for (size_t i = 0; i < 3; i++) {
+      if (!findRootsJenkinsTraub(
+              segment[i].getCoefficients(derivative_order::ACCELERATION),
+              &roots_acc[i])) {
+        return InputFeasibilityResult::kInputIndeterminable;
+      }
     }
-    if (segment.N() - derivative_order::JERK > 1 &&
-        !findRootsJenkinsTraub(
-            segment[i].getCoefficients(derivative_order::JERK),
-            &roots_jerk[i])) {
-      return InputFeasibilityResult::kInputIndeterminable;
+  }
+
+  if (input_constraints_.hasConstraint(InputConstraintType::kFMin) ||
+      input_constraints_.hasConstraint(InputConstraintType::kFMax) ||
+      input_constraints_.hasConstraint(InputConstraintType::kOmegaXYMax)) {
+    roots_jerk.resize(3);
+    for (size_t i = 0; i < 3; i++) {
+      if (!findRootsJenkinsTraub(
+              segment[i].getCoefficients(derivative_order::JERK),
+              &roots_jerk[i])) {
+        return InputFeasibilityResult::kInputIndeterminable;
+      }
     }
-    if (segment.N() - derivative_order::SNAP > 1 &&
-        !findRootsJenkinsTraub(
-            segment[i].getCoefficients(derivative_order::SNAP),
-            &roots_snap[i])) {
-      return InputFeasibilityResult::kInputIndeterminable;
+  }
+
+  if (input_constraints_.hasConstraint(InputConstraintType::kOmegaXYMax)) {
+    roots_snap.resize(3);
+    for (size_t i = 0; i < 3; i++) {
+      if (!findRootsJenkinsTraub(
+              segment[i].getCoefficients(derivative_order::SNAP),
+              &roots_snap[i])) {
+        return InputFeasibilityResult::kInputIndeterminable;
+      }
     }
   }
 
@@ -86,31 +95,42 @@ InputFeasibilityResult FeasibilityRecursive::checkInputFeasibility(
 
   if (segment.D() == 4) {
     // Yaw feasibility (assumed independent of translation in the rigid body
-    // model). Check the single axis minimum / maximum yaw rate:
-    std::pair<double, double> yaw_rate_min, yaw_rate_max;
-    if (!segment[3].computeMinMax(t_1, t_2, derivative_order::ANGULAR_VELOCITY,
-                                  &yaw_rate_min, &yaw_rate_max)) {
-      return InputFeasibilityResult::kInputIndeterminable;
+    // model).
+    // Check the single axis minimum / maximum yaw rate:
+    double yaw_rate_limit;
+    if (input_constraints_.getConstraint(InputConstraintType::kOmegaZMax,
+                                         &yaw_rate_limit)) {
+      std::pair<double, double> yaw_rate_min, yaw_rate_max;
+      if (!segment[3].computeMinMax(t_1, t_2,
+                                    derivative_order::ANGULAR_VELOCITY,
+                                    &yaw_rate_min, &yaw_rate_max)) {
+        return InputFeasibilityResult::kInputIndeterminable;
+      }
+      if (std::max(std::abs(yaw_rate_min.second),
+                   std::abs(yaw_rate_max.second)) > yaw_rate_limit) {
+        return InputFeasibilityResult::kInputInfeasibleYawRates;
+      }
     }
-    if (std::max(std::abs(yaw_rate_min.second), std::abs(yaw_rate_max.second)) >
-        input_constraints_.getOmegaZMax()) {
-      return InputFeasibilityResult::kInputInfeasibleYawRates;
-    }
+
     // Check the single axis minimum / maximum yaw acceleration:
-    std::pair<double, double> yaw_acc_min, yaw_acc_max;
-    if (!segment[3].computeMinMax(t_1, t_2,
-                                  derivative_order::ANGULAR_ACCELERATION,
-                                  &yaw_acc_min, &yaw_acc_max)) {
-      return InputFeasibilityResult::kInputIndeterminable;
-    }
-    if (std::max(std::abs(yaw_acc_min.second), std::abs(yaw_acc_max.second)) >
-        input_constraints_.getOmegaZDotMax()) {
-      return InputFeasibilityResult::kInputInfeasibleYawAcc;
+    double yaw_acc_limit;
+    if (input_constraints_.getConstraint(InputConstraintType::kOmegaZDotMax,
+                                         &yaw_acc_limit)) {
+      std::pair<double, double> yaw_acc_min, yaw_acc_max;
+      if (!segment[3].computeMinMax(t_1, t_2,
+                                    derivative_order::ANGULAR_ACCELERATION,
+                                    &yaw_acc_min, &yaw_acc_max)) {
+        return InputFeasibilityResult::kInputIndeterminable;
+      }
+      if (std::max(std::abs(yaw_acc_min.second), std::abs(yaw_acc_max.second)) >
+          yaw_acc_limit) {
+        return InputFeasibilityResult::kInputInfeasibleYawAcc;
+      }
     }
   }
 
   // Segment definitely feasible.
-  return result;
+  return InputFeasibilityResult::kInputFeasible;
 }
 
 InputFeasibilityResult FeasibilityRecursive::recursiveFeasibility(
@@ -120,21 +140,34 @@ InputFeasibilityResult FeasibilityRecursive::recursiveFeasibility(
     return InputFeasibilityResult::kInputIndeterminable;
   }
   // Evaluate the thrust at the boundaries of the section:
-  const double f_t_1 = evaluateThrust(segment, t_1);
-  const double f_t_2 = evaluateThrust(segment, t_2);
-  if (std::max(f_t_1, f_t_2) > input_constraints_.getFMax()) {
-    return InputFeasibilityResult::kInputInfeasibleThrustHigh;
-  } else if (std::min(f_t_1, f_t_2) < input_constraints_.getFMin()) {
-    return InputFeasibilityResult::kInputInfeasibleThrustLow;
+  if (input_constraints_.hasConstraint(InputConstraintType::kFMin) ||
+      input_constraints_.hasConstraint(InputConstraintType::kFMax)) {
+    const double f_t_1 = evaluateThrust(segment, t_1);
+    const double f_t_2 = evaluateThrust(segment, t_2);
+    double f_min_limit, f_max_limit;
+    if (input_constraints_.getConstraint(InputConstraintType::kFMin,
+                                         &f_min_limit) &&
+        std::min(f_t_1, f_t_2) < f_min_limit) {
+      return InputFeasibilityResult::kInputInfeasibleThrustLow;
+    }
+    if (input_constraints_.getConstraint(InputConstraintType::kFMax,
+                                         &f_max_limit) &&
+        std::max(f_t_1, f_t_2) > f_max_limit) {
+      return InputFeasibilityResult::kInputInfeasibleThrustHigh;
+    }
   }
 
   // Evaluate the velocity at the boundaries of the section:
-  const double v_t_1 =
-      segment.evaluate(t_1, derivative_order::VELOCITY).head<3>().norm();
-  const double v_t_2 =
-      segment.evaluate(t_2, derivative_order::VELOCITY).head<3>().norm();
-  if (std::max(v_t_1, v_t_2) > input_constraints_.getVMax()) {
-    return InputFeasibilityResult::kInputInfeasibleVelocity;
+  double v_max_limit;
+  if (input_constraints_.getConstraint(InputConstraintType::kVMax,
+                                       &v_max_limit)) {
+    const double v_t_1 =
+        segment.evaluate(t_1, derivative_order::VELOCITY).head<3>().norm();
+    const double v_t_2 =
+        segment.evaluate(t_2, derivative_order::VELOCITY).head<3>().norm();
+    if (std::max(v_t_1, v_t_2) > v_max_limit) {
+      return InputFeasibilityResult::kInputInfeasibleVelocity;
+    }
   }
 
   // Upper and lower bounds on thrust, velocity and jerk for this section.
@@ -143,46 +176,72 @@ InputFeasibilityResult FeasibilityRecursive::recursiveFeasibility(
   double v_max_sqr = 0.0;
   double j_max_sqr = 0.0;
 
-  for (size_t i = 0; i < 3; i++) {
-    // Find the minimum / maximum of each axis.
-    std::pair<double, double> v_min, v_max, a_min, a_max, j_min, j_max;
-    segment[i].selectMinMaxFromRoots(t_1, t_2, derivative_order::VELOCITY,
-                                     roots_acc[i], &v_min, &v_max);
-    segment[i].selectMinMaxFromRoots(t_1, t_2, derivative_order::ACCELERATION,
-                                     roots_jerk[i], &a_min, &a_max);
-    segment[i].selectMinMaxFromRoots(t_1, t_2, derivative_order::JERK,
-                                     roots_snap[i], &j_min, &j_max);
-
-    // Distance from zero thrust point in this axis.
-    double f_i_min = a_min.second + gravity_[i];
-    double f_i_max = a_max.second + gravity_[i];
-    // Definitly infeasible:
-    // The thrust on a single axis is higher than the allowed total thrust.
-    if (std::max(std::pow(f_i_min, 2), std::pow(f_i_max, 2)) >
-        std::pow(input_constraints_.getFMax(), 2)) {
-      return InputFeasibilityResult::kInputInfeasibleThrustHigh;
+  // Compute upper bound for velocity.
+  if (input_constraints_.hasConstraint(InputConstraintType::kVMax)) {
+    for (size_t i = 0; i < 3; i++) {
+      std::pair<double, double> v_min, v_max;
+      segment[i].selectMinMaxFromRoots(t_1, t_2, derivative_order::VELOCITY,
+                                       roots_acc[i], &v_min, &v_max);
+      // Definitly infeasible:
+      // The velocity on a single axis is higher than the allowed total
+      // velocity.
+      if (std::max(std::pow(v_min.second, 2), std::pow(v_max.second, 2)) >
+          std::pow(v_max_limit, 2)) {
+        return InputFeasibilityResult::kInputInfeasibleVelocity;
+      }
+      // Add single axis extrema to upper bound on squared velocity.
+      v_max_sqr +=
+          std::pow(std::max(std::abs(v_min.second), std::abs(v_max.second)), 2);
     }
-    // The velocity on a single axis is higher than the allowed total velocity.
-    if (std::max(std::pow(v_min.second, 2), std::pow(v_max.second, 2)) >
-        std::pow(input_constraints_.getVMax(), 2)) {
-      return InputFeasibilityResult::kInputInfeasibleVelocity;
-    }
+  }
 
-    // Add single axis extrema to lower bound on squared acceleration.
-    if (f_i_min * f_i_max < 0.0) {
-      // Sign of acceleration changes. The minimum squared value is zero.
-      f_min_sqr += 0.0;
-    } else {
-      f_min_sqr += std::pow(std::min(std::abs(f_i_min), std::abs(f_i_max)), 2);
-    }
+  // Compute upper and lower bound on thrust.
+  if (input_constraints_.hasConstraint(InputConstraintType::kFMin) ||
+      input_constraints_.hasConstraint(InputConstraintType::kFMax) ||
+      input_constraints_.hasConstraint(InputConstraintType::kOmegaXYMax)) {
+    for (size_t i = 0; i < 3; i++) {
+      std::pair<double, double> a_min, a_max;
+      segment[i].selectMinMaxFromRoots(t_1, t_2, derivative_order::ACCELERATION,
+                                       roots_jerk[i], &a_min, &a_max);
+      // Distance from zero thrust point in this axis.
+      const double f_i_min = a_min.second + gravity_[i];
+      const double f_i_max = a_max.second + gravity_[i];
 
-    // Add single axis extrema to upper bound on squared velocity, acceleration,
-    // and jerk.
-    f_max_sqr += std::pow(std::max(std::abs(f_i_min), std::abs(f_i_max)), 2);
-    v_max_sqr +=
-        std::pow(std::max(std::abs(v_min.second), std::abs(v_max.second)), 2);
-    j_max_sqr +=
-        std::pow(std::max(std::abs(j_min.second), std::abs(j_min.second)), 2);
+      // Definitly infeasible:
+      // The thrust on a single axis is higher than the allowed total thrust.
+      double f_max_limit;
+      if (input_constraints_.getConstraint(InputConstraintType::kFMax,
+                                           &f_max_limit) &&
+          std::max(std::abs(f_i_min), std::abs(f_i_max)) > f_max_limit) {
+        return InputFeasibilityResult::kInputInfeasibleThrustHigh;
+      }
+
+      // Add single axis extrema to lower bound on squared acceleration.
+      if (f_i_min * f_i_max < 0.0) {
+        // Sign of acceleration changes. The minimum squared value is zero.
+        f_min_sqr += 0.0;
+      } else {
+        f_min_sqr +=
+            std::pow(std::min(std::abs(f_i_min), std::abs(f_i_max)), 2);
+      }
+
+      // Add single axis extrema to upper bound on squared acceleration.
+      f_max_sqr += std::pow(std::max(std::abs(f_i_min), std::abs(f_i_max)), 2);
+    }
+  }
+
+  // Compute upper limit on jerk.
+  if (input_constraints_.hasConstraint(InputConstraintType::kOmegaXYMax)) {
+    for (size_t i = 0; i < 3; i++) {
+      // Find the minimum / maximum of each axis.
+      std::pair<double, double> j_min, j_max;
+      segment[i].selectMinMaxFromRoots(t_1, t_2, derivative_order::JERK,
+                                       roots_snap[i], &j_min, &j_max);
+      // Add single axis extrema to upper bound on squared velocity,
+      // acceleration, and jerk.
+      j_max_sqr +=
+          std::pow(std::max(std::abs(j_min.second), std::abs(j_max.second)), 2);
+    }
   }
 
   double f_lower_bound = std::sqrt(f_min_sqr);
@@ -197,18 +256,31 @@ InputFeasibilityResult FeasibilityRecursive::recursiveFeasibility(
   }
 
   // Definitely infeasible:
-  if (f_upper_bound < input_constraints_.getFMin()) {
+  double f_min_limit;
+  if (input_constraints_.getConstraint(InputConstraintType::kFMin,
+                                       &f_min_limit) &&
+      f_upper_bound < f_min_limit) {
     return InputFeasibilityResult::kInputInfeasibleThrustLow;
   }
-  if (f_lower_bound > input_constraints_.getFMax()) {
+
+  double f_max_limit;
+  if (input_constraints_.getConstraint(InputConstraintType::kFMax,
+                                       &f_max_limit) &&
+      f_lower_bound > f_max_limit) {
     return InputFeasibilityResult::kInputInfeasibleThrustHigh;
   }
 
   // Possible infeasible (one of the bounds is exceeding the limits):
-  if (f_lower_bound < input_constraints_.getFMin() ||
-      f_upper_bound > input_constraints_.getFMax() ||
-      v_upper_bound > input_constraints_.getVMax() ||
-      omega_xy_upper_bound > input_constraints_.getOmegaXYMax()) {
+  double omega_xy_limit;
+  if ((input_constraints_.hasConstraint(InputConstraintType::kFMin) &&
+       f_lower_bound < f_min_limit) ||
+      (input_constraints_.hasConstraint(InputConstraintType::kFMax) &&
+       f_upper_bound > f_max_limit) ||
+      (input_constraints_.hasConstraint(InputConstraintType::kVMax) &&
+       v_upper_bound > v_max_limit) ||
+      (input_constraints_.getConstraint(InputConstraintType::kOmegaXYMax,
+                                        &omega_xy_limit) &&
+       omega_xy_upper_bound > omega_xy_limit)) {
     // Indeterminate. Must check more closely:
     double t_half = (t_1 + t_2) / 2;
     InputFeasibilityResult result_1 = recursiveFeasibility(

--- a/mav_trajectory_generation_ros/src/input_constraints.cpp
+++ b/mav_trajectory_generation_ros/src/input_constraints.cpp
@@ -20,27 +20,26 @@
 
 #include <cmath>
 
+#include <glog/logging.h>
+
 #include <mav_msgs/default_values.h>
 
 #include "mav_trajectory_generation_ros/input_constraints.h"
 
 namespace mav_trajectory_generation {
-
 typedef InputConstraintType ICT;
 
 void InputConstraints::addConstraint(int constraint_type, double value) {
   // Correct user input.
   value = std::abs(value);
-  if (constraint_type == ICT::kFMin && hasConstraint(ICT::kFMax) {
+  if (constraint_type == ICT::kFMin && hasConstraint(ICT::kFMax)) {
     constraints_[ICT::kFMax] =
-        value > constraint_[ICT::kFMax] ? value : constraint_[ICT::kFMax];
-  }
-  else if (constraint_type == ICT::kFMax && hasConstraint(ICT::kFMin)) {
-    constraint_[ICT::kFMin] =
-        value < constraint_[ICT::kFMin] ? value : constraint_[ICT::kFMin];
-  }
-  else {
-    constraint_[constraint_type] = value;
+        value > constraints_[ICT::kFMax] ? value : constraints_[ICT::kFMax];
+  } else if (constraint_type == ICT::kFMax && hasConstraint(ICT::kFMin)) {
+    constraints_[ICT::kFMin] =
+        value < constraints_[ICT::kFMin] ? value : constraints_[ICT::kFMin];
+  } else {
+    constraints_[constraint_type] = value;
   }
 }
 
@@ -70,7 +69,7 @@ bool InputConstraints::hasConstraint(int constraint_type) const {
 }
 
 bool InputConstraints::removeConstraint(int constraint_type) {
-  std::map<int, double>::const_iterator it = constraints_.find(type);
+  std::map<int, double>::const_iterator it = constraints_.find(constraint_type);
   if (it != constraints_.end()) {
     constraints_.erase(it);
     return true;

--- a/mav_trajectory_generation_ros/src/input_constraints.cpp
+++ b/mav_trajectory_generation_ros/src/input_constraints.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2016, Markus Achtelik, ASL, ETH Zurich, Switzerland
+ * Copyright (c) 2016, Michael Burri, ASL, ETH Zurich, Switzerland
+ * Copyright (c) 2016, Helen Oleynikova, ASL, ETH Zurich, Switzerland
+ * Copyright (c) 2016, Rik Bähnemann, ASL, ETH Zurich, Switzerland
+ * Copyright (c) 2016, Marija Popovic, ASL, ETH Zurich, Switzerland
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cmath>
+
+#include <mav_msgs/default_values.h>
+
+#include "mav_trajectory_generation_ros/input_constraints.h"
+
+namespace mav_trajectory_generation {
+
+typedef InputConstraintType ICT;
+
+void InputConstraints::addConstraint(int constraint_type, double value) {
+  // Correct user input.
+  value = std::abs(value);
+  if (constraint_type == ICT::kFMin && hasConstraint(ICT::kFMax) {
+    constraints_[ICT::kFMax] =
+        value > constraint_[ICT::kFMax] ? value : constraint_[ICT::kFMax];
+  }
+  else if (constraint_type == ICT::kFMax && hasConstraint(ICT::kFMin)) {
+    constraint_[ICT::kFMin] =
+        value < constraint_[ICT::kFMin] ? value : constraint_[ICT::kFMin];
+  }
+  else {
+    constraint_[constraint_type] = value;
+  }
+}
+
+void InputConstraints::setDefaultValues() {
+  constraints_[ICT::kFMin] = 0.5 * mav_msgs::kGravity;
+  constraints_[ICT::kFMax] = 1.5 * mav_msgs::kGravity;
+  constraints_[ICT::kVMax] = 3.0;
+  constraints_[ICT::kOmegaXYMax] = M_PI / 2.0;
+  constraints_[ICT::kOmegaZMax] = M_PI / 2.0;
+  constraints_[ICT::kOmegaZDotMax] = 2.0 * M_PI;
+}
+
+bool InputConstraints::getConstraint(int constraint_type, double* value) const {
+  CHECK_NOTNULL(value);
+  std::map<int, double>::const_iterator it = constraints_.find(constraint_type);
+  if (it != constraints_.end()) {
+    *value = it->second;
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool InputConstraints::hasConstraint(int constraint_type) const {
+  std::map<int, double>::const_iterator it = constraints_.find(constraint_type);
+  return it != constraints_.end();
+}
+
+bool InputConstraints::removeConstraint(int constraint_type) {
+  std::map<int, double>::const_iterator it = constraints_.find(type);
+  if (it != constraints_.end()) {
+    constraints_.erase(it);
+    return true;
+  } else {
+    return false;
+  }
+}
+
+}  // namespace mav_trajectory_generation


### PR DESCRIPTION
This PR adresses https://github.com/ethz-asl/mav_trajectory_generation/issues/22 .
You can now add a user defined combination of constraints and the feasibility checks only check these. Before the unused constraints were only set to arbitrarily high values.

Is this better?