### PR TITLE
Fix arrow lengths in visualization.

### DIFF
--- a/mav_visualization/include/mav_visualization/helpers.h
+++ b/mav_visualization/include/mav_visualization/helpers.h
@@ -126,9 +126,9 @@ void drawArrowPositionOrientation(const Eigen::Vector3d& p,
   tf::pointEigenToMsg(p, marker->pose.position);
   tf::quaternionEigenToMsg(q, marker->pose.orientation);
 
-  marker->scale.x = diameter;
+  marker->scale.x = length;
   marker->scale.y = diameter;
-  marker->scale.z = length;
+  marker->scale.z = diameter;
 }
 
 void drawArrowPoints(const Eigen::Vector3d& p1, const Eigen::Vector3d& p2,


### PR DESCRIPTION
Based on docs here: http://wiki.ros.org/rviz/DisplayTypes/Marker#Arrow_.28ARROW.3D0.29