### PR TITLE
Fix MarkerArray namespace of hexacopter marker.

### DIFF
--- a/mav_visualization/src/hexacopter_marker.cpp
+++ b/mav_visualization/src/hexacopter_marker.cpp
@@ -118,6 +118,7 @@ void HexacopterMarker::createHexacopter(bool simple) {
     int id = marker.id;
     marker = visualization_msgs::Marker();
     marker.id = id + 1;
+    marker.ns = "hexacopter";
     marker.mesh_resource =
         "package://mav_visualization/meshes/firefly_carbon.dae";
     marker.mesh_use_embedded_materials = false;


### PR DESCRIPTION
Otherwise just shows up as a blank namespace, whereas the rest of the names are descriptive.