### PR TITLE
Fix/polynomial resize and aligned alloc

### DIFF
--- a/mav_trajectory_generation/include/mav_trajectory_generation/polynomial.h
+++ b/mav_trajectory_generation/include/mav_trajectory_generation/polynomial.h
@@ -38,7 +38,7 @@ namespace mav_trajectory_generation {
 // where N = number of coefficients of the polynomial.
 class Polynomial {
  public:
-  typedef std::vector<Polynomial, Eigen::aligned_allocator<Polynomial>> Vector;
+  typedef std::vector<Polynomial> Vector;
 
   // Maximum degree of a polynomial for which the static derivative (basis
   // coefficient) matrix should be evaluated for.
@@ -256,8 +256,6 @@ class Polynomial {
   }
 
  private:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
   int N_;
   Eigen::VectorXd coefficients_;
 };

--- a/mav_trajectory_generation/include/mav_trajectory_generation/segment.h
+++ b/mav_trajectory_generation/include/mav_trajectory_generation/segment.h
@@ -45,7 +45,7 @@ class Segment {
   typedef std::vector<Segment> Vector;
 
   Segment(int N, int D) : time_(0.0), N_(N), D_(D) {
-    polynomials_.resize(D_, N_);
+    polynomials_.resize(D_, Polynomial(N_));
   }
   Segment(const Segment& segment) = default;
 


### PR DESCRIPTION
- No EIGEN_MAKE_ALIGNED_OPERATOR_NEW and Eigen::aligned_allocator needed since no fixed size Eigen matrix 
- fix argument of resize according to: 
void resize (size_type n, const value_type& val);
where value_type val: 
"Object whose content is copied to the added elements in case that n is greater than the current container size.
    If not specified, the default constructor is used instead.
    Member type value_type is the type of the elements in the container, defined in vector as an alias of the first template parameter (T)."

