### PR TITLE
move trajectory_sampling.h/.cpp to mav_traj_gen

### DIFF
--- a/mav_trajectory_generation/CMakeLists.txt
+++ b/mav_trajectory_generation/CMakeLists.txt
@@ -17,6 +17,7 @@ cs_add_library(${PROJECT_NAME}
   src/segment.cpp
   src/timing.cpp
   src/trajectory.cpp
+  src/trajectory_sampling.cpp
   src/vertex.cpp
 )
 

--- a/mav_trajectory_generation/include/mav_trajectory_generation/trajectory_sampling.h
+++ b/mav_trajectory_generation/include/mav_trajectory_generation/trajectory_sampling.h
@@ -18,8 +18,8 @@
  * limitations under the License.
  */
 
-#ifndef MAV_TRAJECTORY_GENERATION_ROS_TRAJECTORY_SAMPLING_H_
-#define MAV_TRAJECTORY_GENERATION_ROS_TRAJECTORY_SAMPLING_H_
+#ifndef MAV_TRAJECTORY_GENERATION_TRAJECTORY_SAMPLING_H_
+#define MAV_TRAJECTORY_GENERATION_TRAJECTORY_SAMPLING_H_
 
 #include <mav_msgs/eigen_mav_msgs.h>
 #include "mav_trajectory_generation/trajectory.h"
@@ -56,4 +56,4 @@ bool sampleFlatStateAtTime(const T& type, double sample_time,
 
 }  // namespace mav_trajectory_generation
 
-#endif  // MAV_TRAJECTORY_GENERATION_ROS_TRAJECTORY_SAMPLING_H_
+#endif  // MAV_TRAJECTORY_GENERATION_TRAJECTORY_SAMPLING_H_

--- a/mav_trajectory_generation/include/mav_trajectory_generation/trajectory_sampling.h
+++ b/mav_trajectory_generation/include/mav_trajectory_generation/trajectory_sampling.h
@@ -22,7 +22,7 @@
 #define MAV_TRAJECTORY_GENERATION_ROS_TRAJECTORY_SAMPLING_H_
 
 #include <mav_msgs/eigen_mav_msgs.h>
-#include <mav_trajectory_generation/trajectory.h>
+#include "mav_trajectory_generation/trajectory.h"
 
 namespace mav_trajectory_generation {
 

--- a/mav_trajectory_generation/package.xml
+++ b/mav_trajectory_generation/package.xml
@@ -21,5 +21,6 @@
   <depend>eigen_catkin</depend>
   <depend>eigen_checks</depend>
   <depend>glog_catkin</depend>
+  <depend>mav_msgs</depend>
   <depend>nlopt</depend>
 </package>

--- a/mav_trajectory_generation/src/trajectory_sampling.cpp
+++ b/mav_trajectory_generation/src/trajectory_sampling.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#include "mav_trajectory_generation_ros/trajectory_sampling.h"
+#include "mav_trajectory_generation/trajectory_sampling.h"
 
 namespace mav_trajectory_generation {
 

--- a/mav_trajectory_generation_ros/CMakeLists.txt
+++ b/mav_trajectory_generation_ros/CMakeLists.txt
@@ -30,7 +30,6 @@ cs_add_library(${PROJECT_NAME}
   src/input_constraints.cpp
   src/ros_conversions.cpp
   src/ros_visualization.cpp
-  src/trajectory_sampling.cpp
   src/yaml_io.cpp
 )
 # Link against yaml-cpp.

--- a/mav_trajectory_generation_ros/include/mav_trajectory_generation_ros/trajectory_sampler_node.h
+++ b/mav_trajectory_generation_ros/include/mav_trajectory_generation_ros/trajectory_sampler_node.h
@@ -32,7 +32,7 @@
 
 #include <mav_trajectory_generation/polynomial.h>
 #include <mav_trajectory_generation_ros/ros_conversions.h>
-#include <mav_trajectory_generation_ros/trajectory_sampling.h>
+#include <mav_trajectory_generation/trajectory_sampling.h>
 
 class TrajectorySamplerNode {
  public:

--- a/mav_trajectory_generation_ros/src/ros_visualization.cpp
+++ b/mav_trajectory_generation_ros/src/ros_visualization.cpp
@@ -23,7 +23,7 @@
 #include <mav_visualization/helpers.h>
 
 #include "mav_trajectory_generation_ros/ros_visualization.h"
-#include "mav_trajectory_generation_ros/trajectory_sampling.h"
+#include "mav_trajectory_generation/trajectory_sampling.h"
 
 namespace mav_trajectory_generation {
 


### PR DESCRIPTION
- move trajectory_sampling.h/cpp from mav_traj_gen_ros to mav_traj_gen
- change dependencies
--> does not have any ros dependencies and is also useful in mav_traj_gen
 