### PR TITLE
Improve time scaling to just stretch trajectory.

### DIFF
--- a/mav_trajectory_generation/include/mav_trajectory_generation/impl/polynomial_optimization_linear_impl.h
+++ b/mav_trajectory_generation/include/mav_trajectory_generation/impl/polynomial_optimization_linear_impl.h
@@ -393,9 +393,7 @@ bool PolynomialOptimization<_N>::computeSegmentMaximumMagnitudeCandidates(
   // Use the implementation of this in the segment (template-free) as it's
   // actually faster.
   std::vector<int> dimensions;
-  for (int i = 0; i < segment.D(); i++) {
-    dimensions.push_back(i);
-  }
+  std::iota(dimensions.begin(), dimensions.end(), 0);
   return segment.computeMinMaxMagnitudeCandidateTimes(
       derivative, t_start, t_stop, dimensions, candidates);
 }

--- a/mav_trajectory_generation/include/mav_trajectory_generation/impl/polynomial_optimization_linear_impl.h
+++ b/mav_trajectory_generation/include/mav_trajectory_generation/impl/polynomial_optimization_linear_impl.h
@@ -392,7 +392,7 @@ bool PolynomialOptimization<_N>::computeSegmentMaximumMagnitudeCandidates(
 
   // Use the implementation of this in the segment (template-free) as it's
   // actually faster.
-  std::vector<int> dimensions;
+  std::vector<int> dimensions(segment.D());
   std::iota(dimensions.begin(), dimensions.end(), 0);
   return segment.computeMinMaxMagnitudeCandidateTimes(
       derivative, t_start, t_stop, dimensions, candidates);

--- a/mav_trajectory_generation/include/mav_trajectory_generation/impl/polynomial_optimization_nonlinear_impl.h
+++ b/mav_trajectory_generation/include/mav_trajectory_generation/impl/polynomial_optimization_nonlinear_impl.h
@@ -368,20 +368,6 @@ void PolynomialOptimizationNonLinear<_N>::scaleSegmentTimesWithViolation() {
   // Get trajectory
   Trajectory traj;
   poly_opt_.getTrajectory(&traj);
-  std::vector<double> segment_times;
-  poly_opt_.getSegmentTimes(&segment_times);
-
-  // Evaluate min/max extrema
-  Extremum v_min_actual, v_max_actual, a_min_actual, a_max_actual;
-  std::vector<int> dimensions;
-  for (int i = 0; i < traj.D(); ++i) {
-    dimensions.push_back(i);
-  }
-
-  traj.computeMinMaxMagnitude(derivative_order::VELOCITY, dimensions,
-                              &v_min_actual, &v_max_actual);
-  traj.computeMinMaxMagnitude(derivative_order::ACCELERATION, dimensions,
-                              &a_min_actual, &a_max_actual);
 
   // Get constraints
   double v_max = 0.0;
@@ -394,67 +380,28 @@ void PolynomialOptimizationNonLinear<_N>::scaleSegmentTimesWithViolation() {
     }
   }
 
-  double velocity_violation = v_max_actual.value / v_max;
-  double acceleration_violation = a_max_actual.value / a_max;
-
-  int counter = 0;
-  const double violation_range = 0.01;
-  const int max_counter = 20;
-  bool within_range = velocity_violation <= 1.0 + violation_range &&
-                      acceleration_violation <= 1.0 + violation_range;
-
   if (optimization_parameters_.print_debug_info_time_allocation) {
-    std::cout << "Beginning  v: max: " << v_max_actual.value << " / " << v_max
-              << " viol: " << velocity_violation
-              << " a: max: " << a_max_actual.value << " / " << a_max
-              << " viol: " << acceleration_violation << std::endl;
+    double v_max_actual, a_max_actual;
+    traj.computeMaxVelocityAndAcceleration(&v_max_actual, &a_max_actual);
+    std::cout << "[Time Scaling] Beginning:  v: max: " << v_max_actual << " / "
+              << v_max << " a: max: " << a_max_actual << " / " << a_max
+              << std::endl;
   }
 
-  while (!within_range && (counter < max_counter)) {
-    // From Liu, Sikang, et al. "Planning Dynamically Feasible Trajectories for
-    // Quadrotors Using Safe Flight Corridors in 3-D Complex Environments." IEEE
-    // Robotics and Automation Letters 2.3 (2017).
+  // Run the trajectory time scaling.
+  traj.scaleSegmentTimesToMeetConstraints(v_max, a_max);
 
-    double violation_scaling = std::max(
-        1.0, std::max(velocity_violation, sqrt(acceleration_violation)));
+  std::vector<double> segment_times;
+  segment_times = traj.getSegmentTimes();
+  poly_opt_.updateSegmentTimes(segment_times);
+  poly_opt_.solveLinear();
 
-    // Convert new segment times
-    std::vector<double> segment_times_new = segment_times;
-    // Check and make sure that segment times are >
-    // kOptimizationTimeLowerBound
-    for (double& t : segment_times_new) {
-      t = std::max(kOptimizationTimeLowerBound, t * violation_scaling);
-    }
-
-    // Update new segment times
-    poly_opt_.updateSegmentTimes(segment_times_new);
-    poly_opt_.solveLinear();
-
-    // Get new trajectory
-    traj.clear();
-    poly_opt_.getTrajectory(&traj);
-
-    // Reevaluate min/max extrema
-    traj.computeMinMaxMagnitude(derivative_order::VELOCITY, dimensions,
-                                &v_min_actual, &v_max_actual);
-    traj.computeMinMaxMagnitude(derivative_order::ACCELERATION, dimensions,
-                                &a_min_actual, &a_max_actual);
-
-    // Reevaluate constraint/bound violation
-    velocity_violation = v_max_actual.value / v_max;
-    acceleration_violation = a_max_actual.value / a_max;
-
-    if (optimization_parameters_.print_debug_info_time_allocation) {
-      std::cout << "Iteration " << counter << " v: max: " << v_max_actual.value
-                << " / " << v_max << " viol: " << velocity_violation
-                << " a: max: " << a_max_actual.value << " / " << a_max
-                << " viol: " << acceleration_violation
-                << " total time: " << traj.getMaxTime() << std::endl;
-    }
-
-    within_range = velocity_violation <= 1.0 + violation_range &&
-                   acceleration_violation <= 1.0 + violation_range;
-    counter++;
+  if (optimization_parameters_.print_debug_info_time_allocation) {
+    double v_max_actual, a_max_actual;
+    traj.computeMaxVelocityAndAcceleration(&v_max_actual, &a_max_actual);
+    std::cout << "[Time Scaling] End: v: max: " << v_max_actual << " / "
+              << v_max << " a: max: " << a_max_actual << " / " << a_max
+              << std::endl;
   }
 }
 

--- a/mav_trajectory_generation/include/mav_trajectory_generation/polynomial.h
+++ b/mav_trajectory_generation/include/mav_trajectory_generation/polynomial.h
@@ -104,9 +104,10 @@ class Polynomial {
       result.setZero();
       result.head(N_ - derivative) =
           coefficients_.tail(N_ - derivative)
-              .cwiseProduct(base_coefficients_.block(derivative, derivative, 1,
-                                                     N_ - derivative)
-                                .transpose());
+              .cwiseProduct(
+                  base_coefficients_
+                      .block(derivative, derivative, 1, N_ - derivative)
+                      .transpose());
       return result;
     }
   }
@@ -148,7 +149,7 @@ class Polynomial {
   }
 
   // Uses Jenkins-Traub to get all the roots of the polynomial at a certain
-  //
+  // derivative.
   bool getRoots(int derivative, Eigen::VectorXcd* roots) const;
 
   // Finds all candidates for the minimum and maximum between t_start and t_end
@@ -234,6 +235,12 @@ class Polynomial {
   static inline int getConvolutionLength(int data_size, int kernel_size) {
     return data_size + kernel_size - 1;
   }
+
+  // Scales the polynomial in time with a scaling factor.
+  // To stretch out by a factor of 10, pass scaling_factor (b) = 1/10. To shrink
+  // by a factor of 10, pass scalign factor = 10.
+  // p_out = a12*b^12*t^12 + a11*b^11*t^11... etc.
+  void scalePolynomialInTime(double scaling_factor);
 
  private:
   int N_;

--- a/mav_trajectory_generation/include/mav_trajectory_generation/trajectory.h
+++ b/mav_trajectory_generation/include/mav_trajectory_generation/trajectory.h
@@ -91,7 +91,7 @@ class Trajectory {
 
   // Add trajectories with same dimensions and coefficients to this trajectory.
   bool addTrajectories(const std::vector<Trajectory>& trajectories,
-                         Trajectory* merged) const;
+                       Trajectory* merged) const;
 
   // Evaluate the vertex constraint at time t.
   Vertex getVertexAtTime(double t, int max_derivative_order) const;
@@ -119,6 +119,14 @@ class Trajectory {
   bool computeMinMaxMagnitude(int derivative,
                               const std::vector<int>& dimensions,
                               Extremum* minimum, Extremum* maximum) const;
+
+  // Compute max velocity and max acceleration. Shorthand for the method above.
+  bool computeMaxVelocityAndAcceleration(double* v_max, double* a_max) const;
+
+  // This method SCALES the segment times evenly to ensure that the trajectory
+  // is feasible given the provided v_max and a_max. Does not change the shape
+  // of the trajectory, and only *increases* segment times.
+  bool scaleSegmentTimesToMeetConstraints(double v_max, double a_max);
 
  private:
   int D_;            // Number of dimensions.

--- a/mav_trajectory_generation/src/polynomial.cpp
+++ b/mav_trajectory_generation/src/polynomial.cpp
@@ -196,6 +196,12 @@ bool Polynomial::getPolynomialWithAppendedCoefficients(
   }
 }
 
+void Polynomial::scalePolynomialInTime(double scaling_factor) {
+  for (int n = 0; n < N_; n++) {
+    coefficients_[n] *= pow(scaling_factor, n);
+  }
+}
+
 Eigen::MatrixXd Polynomial::base_coefficients_ =
     computeBaseCoefficients(Polynomial::kMaxConvolutionSize);
 

--- a/mav_trajectory_generation/src/polynomial.cpp
+++ b/mav_trajectory_generation/src/polynomial.cpp
@@ -197,8 +197,10 @@ bool Polynomial::getPolynomialWithAppendedCoefficients(
 }
 
 void Polynomial::scalePolynomialInTime(double scaling_factor) {
+  double scale = 1.0;
   for (int n = 0; n < N_; n++) {
-    coefficients_[n] *= pow(scaling_factor, n);
+    coefficients_[n] *= scale;
+    scale *= scaling_factor;
   }
 }
 

--- a/mav_trajectory_generation/src/trajectory.cpp
+++ b/mav_trajectory_generation/src/trajectory.cpp
@@ -264,4 +264,85 @@ Vertex Trajectory::getGoalVertex(int max_derivative_order) const {
   return getVertexAtTime(max_time_, max_derivative_order);
 }
 
+// Compute max velocity and max acceleration.
+bool Trajectory::computeMaxVelocityAndAcceleration(double* v_max,
+                                                   double* a_max) const {
+  std::vector<int> dimensions;  // Evaluate in whatever dimensions we have.
+  for (int i = 0; i < D_; i++) {
+    dimensions.push_back(i);
+  }
+  Extremum v_min_traj, v_max_traj, a_min_traj, a_max_traj;
+
+  bool success = computeMinMaxMagnitude(
+      mav_trajectory_generation::derivative_order::VELOCITY, dimensions,
+      &v_min_traj, &v_max_traj);
+  success &= computeMinMaxMagnitude(
+      mav_trajectory_generation::derivative_order::ACCELERATION, dimensions,
+      &a_min_traj, &a_max_traj);
+
+  *v_max = v_max_traj.value;
+  *a_max = a_max_traj.value;
+  return success;
+}
+
+// This method SCALES the segment times evenly to ensure that the trajectory
+// is feasible given the provided v_max and a_max. Does not change the shape
+// of the trajectory, and only *increases* segment times.
+bool Trajectory::scaleSegmentTimesToMeetConstraints(double v_max,
+                                                    double a_max) {
+  double v_max_actual, a_max_actual;
+  computeMaxVelocityAndAcceleration(&v_max_actual, &a_max_actual);
+
+  double velocity_violation = v_max_actual / v_max;
+  double acceleration_violation = a_max_actual / a_max;
+
+  int counter = 0;
+  // In vast majority of cases, this will converge within 1 iteration.
+  constexpr int kMaxCounter = 20;
+  constexpr double kTolerance = 1e-3;
+  bool within_range = velocity_violation <= 1.0 + kTolerance &&
+                      acceleration_violation <= 1.0 + kTolerance;
+
+  while (!within_range && (counter < kMaxCounter)) {
+    // From Liu, Sikang, et al. "Planning Dynamically Feasible Trajectories for
+    // Quadrotors Using Safe Flight Corridors in 3-D Complex Environments." IEEE
+    // Robotics and Automation Letters 2.3 (2017).
+
+    double violation_scaling = std::max(
+        1.0, std::max(velocity_violation, sqrt(acceleration_violation)));
+    std::cout << "Vel violation: " << velocity_violation
+              << " accel violation: " << acceleration_violation
+              << " v max: " << v_max << " a max: " << a_max
+              << " scaling: " << violation_scaling << std::endl;
+
+    // First figure out how to stretch the trajectory in time.
+    double violation_scaling_inverse = 1.0 / violation_scaling;
+
+    // Scale the segment times of each segment.
+    double new_max_time = 0.0;
+    for (size_t i = 0; i < segments_.size(); i++) {
+      double new_time = segments_[i].getTime() * violation_scaling;
+      for (int d = 0; d < segments_[i].D(); d++) {
+        (segments_[i])[d].scalePolynomialInTime(violation_scaling_inverse);
+      }
+      segments_[i].setTime(new_time);
+      new_max_time += new_time;
+    }
+    max_time_ = new_max_time;
+
+    // Reevaluate min/max extrema
+    v_max_actual = 0.0;
+    computeMaxVelocityAndAcceleration(&v_max_actual, &a_max_actual);
+
+    // Reevaluate constraint/bound violation
+    velocity_violation = v_max_actual / v_max;
+    acceleration_violation = a_max_actual / a_max;
+
+    within_range = velocity_violation <= 1.0 + kTolerance &&
+                   acceleration_violation <= 1.0 + kTolerance;
+    counter++;
+  }
+  return within_range;
+}
+
 }  // namespace mav_trajectory_generation

--- a/mav_trajectory_generation/src/trajectory.cpp
+++ b/mav_trajectory_generation/src/trajectory.cpp
@@ -310,10 +310,6 @@ bool Trajectory::scaleSegmentTimesToMeetConstraints(double v_max,
 
     double violation_scaling = std::max(
         1.0, std::max(velocity_violation, sqrt(acceleration_violation)));
-    std::cout << "Vel violation: " << velocity_violation
-              << " accel violation: " << acceleration_violation
-              << " v max: " << v_max << " a max: " << a_max
-              << " scaling: " << violation_scaling << std::endl;
 
     // First figure out how to stretch the trajectory in time.
     double violation_scaling_inverse = 1.0 / violation_scaling;

--- a/mav_trajectory_generation/src/trajectory.cpp
+++ b/mav_trajectory_generation/src/trajectory.cpp
@@ -267,7 +267,7 @@ Vertex Trajectory::getGoalVertex(int max_derivative_order) const {
 // Compute max velocity and max acceleration.
 bool Trajectory::computeMaxVelocityAndAcceleration(double* v_max,
                                                    double* a_max) const {
-  std::vector<int> dimensions;  // Evaluate in whatever dimensions we have.
+  std::vector<int> dimensions(D_);  // Evaluate in whatever dimensions we have.
   std::iota(dimensions.begin(), dimensions.end(), 0);
 
   Extremum v_min_traj, v_max_traj, a_min_traj, a_max_traj;

--- a/mav_trajectory_generation/src/vertex.cpp
+++ b/mav_trajectory_generation/src/vertex.cpp
@@ -238,11 +238,14 @@ std::vector<double> estimateSegmentTimesVelocityRamp(
 
   segment_times.reserve(vertices.size() - 1);
 
+  constexpr double kMinSegmentTime = 0.1;
+
   for (size_t i = 0; i < vertices.size() - 1; ++i) {
     Eigen::VectorXd start, end;
     vertices[i].getConstraint(derivative_order::POSITION, &start);
     vertices[i + 1].getConstraint(derivative_order::POSITION, &end);
     double t = computeTimeVelocityRamp(start, end, v_max, a_max);
+    t = std::max(kMinSegmentTime, t);
     segment_times.push_back(t);
   }
 

--- a/mav_trajectory_generation/test/test_polynomial_optimization.cpp
+++ b/mav_trajectory_generation/test/test_polynomial_optimization.cpp
@@ -199,9 +199,8 @@ bool PolynomialOptimizationTests::checkCost(double cost_to_check,
 void PolynomialOptimizationTests::getMaxVelocityAndAccelerationAnalytical(
     const Trajectory& trajectory, double* v_max, double* a_max) const {
   std::vector<int> dimensions;  // Evaluate in whatever dimensions we have.
-  for (int i = 0; i < trajectory.D(); i++) {
-    dimensions.push_back(i);
-  }
+  std::iota(dimensions.begin(), dimensions.end(), 0);
+
   mav_trajectory_generation::Extremum v_min_traj, v_max_traj, a_min_traj,
       a_max_traj;
 
@@ -322,9 +321,8 @@ TEST_P(PolynomialOptimizationTests, ExtremaOfMagnitude) {
   opt.getTrajectory(&trajectory);
 
   std::vector<int> dimensions;
-  for (int i = 0; i < D; i++) {
-    dimensions.push_back(i);
-  }
+  std::iota(dimensions.begin(), dimensions.end(), 0);
+
   timing::Timer time_analytic("time_extrema_analytic" + getSuffix(), false);
   timing::Timer time_sampling("time_extrema_sampling" + getSuffix(), false);
   int segment_idx = 0;

--- a/mav_trajectory_generation/test/test_polynomial_optimization.cpp
+++ b/mav_trajectory_generation/test/test_polynomial_optimization.cpp
@@ -135,7 +135,8 @@ void PolynomialOptimizationTests::checkPath(
       EXPECT_TRUE(EIGEN_MATRIX_NEAR(desired, actual, tol))
           << "[fixed constraint check t=0] at vertex " << i
           << " and constraint " << positionDerivativeToString(derivative)
-          << "\nsegment:\n" << segment << segment_derivative.str();
+          << "\nsegment:\n"
+          << segment << segment_derivative.str();
     }
     for (Vertex::Constraints::const_iterator it = v_end.cBegin();
          it != v_end.cEnd(); ++it) {
@@ -148,7 +149,8 @@ void PolynomialOptimizationTests::checkPath(
       EXPECT_TRUE(EIGEN_MATRIX_NEAR(desired, actual, tol))
           << "[fixed constraint check] at vertex " << i + 1
           << " and constraint " << positionDerivativeToString(derivative)
-          << "\nsegment:\n" << segment << segment_derivative.str();
+          << "\nsegment:\n"
+          << segment << segment_derivative.str();
     }
 
     // Check if values at vertices are continuous.
@@ -515,7 +517,7 @@ TEST_P(PolynomialOptimizationTests, ConstraintPacking) {
   min_pos = Eigen::VectorXd::Constant(D, -50.0);
   max_pos = -min_pos;
   const int kSeed = 12345;
-  const size_t kNumSetups = 10;
+  const size_t kNumSetups = 5;
 
   for (size_t i = 0; i < kNumSetups; i++) {
     Vertex::Vector vertices;
@@ -692,6 +694,49 @@ TEST_P(PolynomialOptimizationTests, TimeScaling) {
   EXPECT_LE(mellinger_cost, scaled_cost);
 }
 
+TEST_P(PolynomialOptimizationTests, TimeScalingInTrajectory) {
+  constexpr double kTolerance = 1e-3;
+
+  std::vector<double> segment_times =
+      estimateSegmentTimesVelocityRamp(vertices_, v_max * 2.0, a_max * 2.0);
+  EXPECT_EQ(segment_times.size(), params_.num_segments);
+
+  PolynomialOptimization<N> opt(D);
+  opt.setupFromVertices(vertices_, segment_times, max_derivative);
+  opt.solveLinear();
+
+  Trajectory trajectory;
+  opt.getTrajectory(&trajectory);
+
+  double v_max_traj, a_max_traj, v_max_num, a_max_num;
+  getMaxVelocityAndAccelerationAnalytical(trajectory, &v_max_traj, &a_max_traj);
+  getMaxVelocityAndAccelerationNumerical(trajectory, &v_max_num, &a_max_num);
+
+  std::cout << "Starting v max: " << v_max_traj << " (" << v_max_num
+            << ") a max: " << a_max_traj << " (" << a_max_num << ")"
+            << std::endl;
+
+  EXPECT_LE(v_max_traj, v_max * 5.0);
+  EXPECT_LE(a_max_traj, a_max * 5.0);
+
+  EXPECT_NEAR(v_max_traj, v_max_num, kTolerance);
+  EXPECT_NEAR(a_max_traj, a_max_num, kTolerance);
+
+  // Scaling of segment times
+  trajectory.scaleSegmentTimesToMeetConstraints(v_max, a_max);
+  getMaxVelocityAndAccelerationAnalytical(trajectory, &v_max_traj, &a_max_traj);
+  getMaxVelocityAndAccelerationNumerical(trajectory, &v_max_num, &a_max_num);
+  std::cout << "Scaled v max: " << v_max_traj << " (" << v_max_num
+            << ") a max: " << a_max_traj << " (" << a_max_num << ")"
+            << std::endl;
+
+  EXPECT_NEAR(v_max_traj, v_max_num, kTolerance);
+  EXPECT_NEAR(a_max_traj, a_max_num, kTolerance);
+
+  EXPECT_LE(v_max_traj, v_max + kTolerance);
+  EXPECT_LE(a_max_traj, a_max + kTolerance);
+}
+
 TEST_P(PolynomialOptimizationTests, AMatrixInversion) {
   const double max_time = 60;
   for (double t = 1; t <= max_time; t += 1) {
@@ -799,14 +844,6 @@ OptimizationParams segment_50_dim_3 = {3 /* D */,
                                        3.0 /* v_max */,
                                        5.0 /* a_mav */};
 
-OptimizationParams segment_75_dim_3 = {3 /* D */,
-                                       derivative_order::SNAP,
-                                       75 /* num_segments*/,
-                                       106 /* seed */,
-                                       10.0 /* pos_max */,
-                                       3.0 /* v_max */,
-                                       5.0 /* a_mav */};
-
 OptimizationParams deriv_accel_1 = {1 /* D */,
                                     derivative_order::ACCELERATION,
                                     5 /* num_segments*/,
@@ -844,7 +881,7 @@ INSTANTIATE_TEST_CASE_P(OneDimension, PolynomialOptimizationTests,
 
 INSTANTIATE_TEST_CASE_P(ThreeDimensions, PolynomialOptimizationTests,
                         ::testing::Values(segment_1_dim_3, segment_10_dim_3,
-                                          segment_50_dim_3, segment_75_dim_3));
+                                          segment_50_dim_3));
 
 INSTANTIATE_TEST_CASE_P(Derivatives, PolynomialOptimizationTests,
                         ::testing::Values(deriv_accel_1, deriv_accel_3_1,

--- a/mav_trajectory_generation/test/test_polynomial_optimization.cpp
+++ b/mav_trajectory_generation/test/test_polynomial_optimization.cpp
@@ -198,7 +198,7 @@ bool PolynomialOptimizationTests::checkCost(double cost_to_check,
 
 void PolynomialOptimizationTests::getMaxVelocityAndAccelerationAnalytical(
     const Trajectory& trajectory, double* v_max, double* a_max) const {
-  std::vector<int> dimensions;  // Evaluate in whatever dimensions we have.
+  std::vector<int> dimensions(D);  // Evaluate in whatever dimensions we have.
   std::iota(dimensions.begin(), dimensions.end(), 0);
 
   mav_trajectory_generation::Extremum v_min_traj, v_max_traj, a_min_traj,

--- a/mav_trajectory_generation/test/test_polynomial_optimization.cpp
+++ b/mav_trajectory_generation/test/test_polynomial_optimization.cpp
@@ -320,7 +320,7 @@ TEST_P(PolynomialOptimizationTests, ExtremaOfMagnitude) {
   Trajectory trajectory;
   opt.getTrajectory(&trajectory);
 
-  std::vector<int> dimensions;
+  std::vector<int> dimensions(D);
   std::iota(dimensions.begin(), dimensions.end(), 0);
 
   timing::Timer time_analytic("time_extrema_analytic" + getSuffix(), false);


### PR DESCRIPTION
Changes:
 - Adds a function to stretch or compress a polynomial in time.
 - Uses this new function in the trajectory, which means any trajectory can be scaled to meet constraints. Before would still solve linearly to get new coefficients, which means couldn't use this in loco.
 - Changes nlopt to change this implementation instead.