### PR TITLE
std::iota error fixed

### DIFF
--- a/mav_trajectory_generation/include/mav_trajectory_generation/impl/polynomial_optimization_linear_impl.h
+++ b/mav_trajectory_generation/include/mav_trajectory_generation/impl/polynomial_optimization_linear_impl.h
@@ -26,7 +26,17 @@
 #include <set>
 #include <tuple>
 
+// fixes error due to std::iota (has been introduced in c++ standard lately 
+// and may cause compilation errors depending on compiler)
+#if __cplusplus <= 199711L
+  #include <algorithm>
+#else
+  #include <numeric>
+#endif
+
 #include "mav_trajectory_generation/convolution.h"
+
+
 
 namespace mav_trajectory_generation {
 

--- a/mav_trajectory_generation/src/trajectory.cpp
+++ b/mav_trajectory_generation/src/trajectory.cpp
@@ -19,8 +19,15 @@
  */
 
 #include "mav_trajectory_generation/trajectory.h"
-
 #include <limits>
+
+// fixes error due to std::iota (has been introduced in c++ standard lately 
+// and may cause compilation errors depending on compiler)
+#if __cplusplus <= 199711L
+  #include <algorithm>
+#else
+  #include <numeric>
+#endif
 
 namespace mav_trajectory_generation {
 


### PR DESCRIPTION
Issue:
Did not compile on gcc 7.3.0 (default on ubuntu 18.04). Error: 'iota’ is not a member of ‘std’. C++11 was activated, so that wasn't the issue.

Reason:
std::iota has been introduced into the standard lately and may be in different headers for different compilers, even if they're c++11 compliant. Hopefully that fixes it.

@helenol  ptal and check if it still compiles on your machine ;-)