### PR TITLE
Example Planner

### DIFF
--- a/mav_trajectory_generation_example/CMakeLists.txt
+++ b/mav_trajectory_generation_example/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(mav_trajectory_generation_example)
+
+find_package(catkin_simple REQUIRED)
+catkin_simple(ALL_DEPS_REQUIRED)
+
+set(CMAKE_MACOSX_RPATH 0)
+add_definitions(-std=c++11)
+
+############
+# BINARIES #
+############
+cs_add_executable(trajectory_generation_example
+        src/example_planner.cc
+        src/example_planner_node.cc
+)
+
+##########
+# EXPORT #
+##########
+cs_install()
+cs_export()

--- a/mav_trajectory_generation_example/cfg/rviz_view.rviz
+++ b/mav_trajectory_generation_example/cfg/rviz_view.rviz
@@ -1,0 +1,194 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 70
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /Grid1
+        - /TF1
+        - /TF1/Frames1
+        - /TF1/Tree1
+      Splitter Ratio: 0.5050651431083679
+    Tree Height: 810
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 0.10000000149011612
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 100
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /firefly/trajectory_markers
+      Name: MarkerArray
+      Namespaces:
+        {}
+      Queue Size: 100
+      Value: true
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: false
+        firefly/base_link:
+          Value: true
+        firefly/base_link_inertia:
+          Value: false
+        firefly/imu_link:
+          Value: false
+        firefly/imugt_link:
+          Value: false
+        firefly/odometry_sensor1:
+          Value: false
+        firefly/odometry_sensor1_link:
+          Value: false
+        firefly/odometry_sensorgt_link:
+          Value: false
+        firefly/rotor_0:
+          Value: false
+        firefly/rotor_1:
+          Value: false
+        firefly/rotor_2:
+          Value: false
+        firefly/rotor_3:
+          Value: false
+        firefly/rotor_4:
+          Value: false
+        firefly/rotor_5:
+          Value: false
+        world:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        world:
+          firefly/base_link:
+            firefly/base_link_inertia:
+              {}
+            firefly/imu_link:
+              {}
+            firefly/imugt_link:
+              {}
+            firefly/odometry_sensor1_link:
+              {}
+            firefly/odometry_sensorgt_link:
+              {}
+            firefly/rotor_0:
+              {}
+            firefly/rotor_1:
+              {}
+            firefly/rotor_2:
+              {}
+            firefly/rotor_3:
+              {}
+            firefly/rotor_4:
+              {}
+            firefly/rotor_5:
+              {}
+          firefly/odometry_sensor1:
+            {}
+      Update Interval: 0
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 0; 0; 0
+    Default Light: true
+    Fixed Frame: world
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 4.325163841247559
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0.6926935315132141
+        Y: 0.03723691403865814
+        Z: 1.6252400875091553
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.2497968226671219
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 0.49118542671203613
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1031
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd000000040000000000000247000003adfc0200000016fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afc0000003d000003ad000000c900fffffffa000000010100000002fb0000000a0049006d0061006700650000000000ffffffff0000000000000000fb000000100044006900730070006c0061007900730100000000000002b50000015600fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d006100670065000000019c000002c60000000000000000fb0000000a0049006d00610067006500000001930000028b0000000000000000fb0000000a0049006d0061006700650000000239000001fe0000000000000000fb0000000a0049006d006100670065000000021a000000b40000000000000000fb0000000a0049006d00610067006500000001a00000027e0000000000000000fb0000000a0049006d0061006700650100000219000002050000000000000000fb0000000a0049006d006100670065000000021b0000021c0000000000000000fb0000000a0049006d00610067006501000001ed0000024a0000000000000000fb0000000a0049006d00610067006502fffffff20000023e00000205000001bcfb0000000a0049006d0061006700650100000167000000f90000000000000000fb0000000a0049006d0061006700650100000266000001400000000000000000fb0000000a0049006d00610067006501000002de000000c80000000000000000fb0000000a0049006d00610067006501000001ac000002cf0000000000000000fb0000000a0049006d0061006700650100000264000001fe0000000000000000000000010000014b000003adfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fc0000003d000003ad000000a400fffffffa000000010100000002fb0000000a0049006d0061006700650000000000ffffffff0000000000000000fb0000000a0056006900650077007301000006710000010f0000010000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e1000001970000000300000780000001e3fc0100000002fb0000000800540069006d006500000002bb000004c50000025600fffffffb0000000800540069006d00650100000000000004500000000000000000000003e0000003ad00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1918
+  X: 0
+  Y: 25

--- a/mav_trajectory_generation_example/include/mav_trajectory_generation_example/example_planner.h
+++ b/mav_trajectory_generation_example/include/mav_trajectory_generation_example/example_planner.h
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <ros/ros.h>
+#include <Eigen/Dense>
+#include <eigen_conversions/eigen_msg.h>
+#include <mav_trajectory_generation/polynomial_optimization_linear.h>
+#include <mav_trajectory_generation_ros/ros_visualization.h>
+#include <mav_trajectory_generation_ros/ros_conversions.h>
+
+class ExamplePlanner {
+ public:
+  ExamplePlanner(ros::NodeHandle& nh);
+
+  void uavPoseCallback(const geometry_msgs::Pose::ConstPtr& pose);
+
+  void getCurrentPose(Eigen::Affine3d* current);
+
+  void setMaxSpeed(double max_v);
+
+  // Plans a trajectory to take off from the current position and
+  // fly to the given altitude (while maintaining x,y, and yaw).
+  bool planTakeOffTrajectory(double altitude);
+
+  // Visualize the last planned trajectory
+  void visualizeCachedTrajectory();
+
+  // Output last planned trajectory
+  void executeCachedTrajectory();
+
+ private:
+  ros::Publisher pub_markers_;
+  ros::Publisher pub_trajectory_;
+  ros::Subscriber sub_pose_;
+
+  ros::NodeHandle& nh_;
+  Eigen::Affine3d current_position_;
+  double max_v_; // m/s
+  double max_a_; // m/s^2
+  double safety_altitude_; // m above take-off height.
+  mav_trajectory_generation::Trajectory trajectory_;
+
+};

--- a/mav_trajectory_generation_example/launch/example.launch
+++ b/mav_trajectory_generation_example/launch/example.launch
@@ -1,0 +1,54 @@
+<launch>
+    <arg name="mav_name" default="firefly"/>
+    <arg name="world_name" default="basic"/>
+    <arg name="enable_logging" default="false" />
+    <arg name="enable_ground_truth" default="true" />
+    <arg name="log_file" default="$(arg mav_name)" />
+    <arg name="debug" default="false"/>
+    <arg name="gui" default="true"/>
+    <arg name="paused" default="false"/>
+    <!-- The following line causes gzmsg and gzerr messages to be printed to the console
+        (even when Gazebo is started through roslaunch) -->
+    <arg name="verbose" default="false"/>
+
+    <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
+    <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world" />
+        <arg name="debug" value="$(arg debug)" />
+        <arg name="paused" value="$(arg paused)" />
+        <arg name="gui" value="$(arg gui)" />
+        <arg name="verbose" value="$(arg verbose)"/>
+    </include>
+
+    <group ns="$(arg mav_name)">
+        <include file="$(find rotors_gazebo)/launch/spawn_mav.launch">
+            <arg name="mav_name" value="$(arg mav_name)" />
+            <arg name="model" value="$(find rotors_description)/urdf/mav_generic_odometry_sensor.gazebo" />
+            <arg name="enable_logging" value="$(arg enable_logging)" />
+            <arg name="enable_ground_truth" value="$(arg enable_ground_truth)" />
+            <arg name="log_file" value="$(arg log_file)"/>
+        </include>
+        <node name="lee_position_controller_node" pkg="rotors_control" type="lee_position_controller_node" output="screen">
+            <rosparam command="load" file="$(find rotors_gazebo)/resource/lee_controller_$(arg mav_name).yaml" />
+            <rosparam command="load" file="$(find rotors_gazebo)/resource/$(arg mav_name).yaml" />
+            <remap from="odometry" to="odometry_sensor1/odometry" />
+        </node>
+        <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+        <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+
+
+        <!--- Trajectory planner -->
+        <node name="planner" pkg="mav_trajectory_generation_example" type="trajectory_generation_example" output="screen">
+            <remap from="uav_pose" to="odometry_sensor1/pose"/>
+        </node>
+
+        <!--- Trajectory sampler -->
+        <node name="sampler" pkg="mav_trajectory_generation_ros" type="trajectory_sampler_node" output="screen">
+            <remap from="path_segments" to="trajectory"/>
+        </node>
+
+    </group>
+
+    <node type="rviz" name="rviz" pkg="rviz" args="-d $(find mav_trajectory_generation_example)/cfg/rviz_view.rviz" />
+</launch>

--- a/mav_trajectory_generation_example/package.xml
+++ b/mav_trajectory_generation_example/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>mav_trajectory_generation_example</name>
+  <version>0.0.0</version>
+  <description>Example of a simple trajectory generation node</description>
+
+  <author email="michael.pantic@mavt.ethz.ch">Michael Pantic</author>
+  <maintainer email="michael.pantic@mavt.ethz.ch">Michael Pantic</maintainer>
+
+
+  <license>ASL 2.0</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>catkin_simple</buildtool_depend>
+
+  <depend>eigen_catkin</depend>
+  <depend>mav_msgs</depend>
+  <depend>mav_trajectory_generation</depend>
+  <depend>mav_trajectory_generation_ros</depend>
+  <depend>mav_visualization</depend>
+  <depend>mav_planning_msgs</depend>
+  <depend>eigen_checks</depend>
+  <depend>roslib</depend>
+</package>

--- a/mav_trajectory_generation_example/src/example_planner.cc
+++ b/mav_trajectory_generation_example/src/example_planner.cc
@@ -1,0 +1,143 @@
+#include <mav_trajectory_generation_example/example_planner.h>
+
+ExamplePlanner::ExamplePlanner(ros::NodeHandle& nh) :
+    nh_(nh),
+    max_v_(2.0),
+    max_a_(2.0),
+    safety_altitude_(0.5),
+    current_position_(Eigen::Affine3d::Identity()) {
+
+  // create publisher for RVIZ markers
+  pub_markers_ =
+      nh.advertise<visualization_msgs::MarkerArray>("trajectory_markers", 0);
+
+  pub_trajectory_ =
+      nh.advertise<mav_planning_msgs::PolynomialTrajectory4D>("trajectory",
+                                                              0);
+
+  // subscriber for pose
+  sub_pose_ =
+      nh.subscribe("uav_pose", 1, &ExamplePlanner::uavPoseCallback, this);
+}
+
+void ExamplePlanner::uavPoseCallback(const geometry_msgs::Pose::ConstPtr& pose) {
+  tf::poseMsgToEigen(*pose, current_position_);
+}
+
+void ExamplePlanner::getCurrentPose(Eigen::Affine3d* current) {
+  *current = current_position_;
+}
+
+void ExamplePlanner::setMaxSpeed(const double max_v) {
+  max_v_ = max_v;
+}
+
+// Plans a trajectory to take off from the current position and
+// fly to the given altitude (while maintaining x,y, and yaw).
+bool ExamplePlanner::planTakeOffTrajectory(const double altitude) {
+
+  // check if actually a take off
+  if (altitude < 0) {
+    ROS_WARN("Not a takeoff - not executing");
+    return false;
+  }
+
+  const double
+      target_altitude = current_position_.translation().z() + altitude;
+
+  bool above_safety = altitude > safety_altitude_;
+
+  mav_trajectory_generation::Vertex::Vector vertices;
+  const int dimension = 3;
+  const int derivative_to_optimize =
+      mav_trajectory_generation::derivative_order::SNAP;
+
+  // we have 3 vertices:
+  // Start = current position
+  // middle = a point 50 cm above ground that we approach with slower velocity.
+  // end = Final point that is approach with max velocity.
+  mav_trajectory_generation::Vertex start(dimension), middle(dimension),
+      end(dimension);
+
+  // set start point constraints
+  // (current position, and everything else zero)
+  start.makeStartOrEnd(current_position_.translation(),
+                       derivative_to_optimize);
+  vertices.push_back(start);
+
+  // set middle point constraints
+  Eigen::Vector3d middle_point_position = current_position_.translation();
+
+  // if we are above safety threshold, this is only an intermediate position
+  if (above_safety) {
+    middle_point_position.z() += safety_altitude_;
+    middle.addConstraint(mav_trajectory_generation::derivative_order::POSITION,
+                         middle_point_position);
+
+    Eigen::Vector3d middle_point_velocity;
+    middle_point_velocity << 0.0, 0.0, max_v_ * 0.1;
+    middle.addConstraint(mav_trajectory_generation::derivative_order::VELOCITY,
+                         middle_point_velocity);
+  } else {
+    // if not, this is the final waypoint.
+    middle_point_position.z() = target_altitude;
+    middle.makeStartOrEnd(middle_point_position, derivative_to_optimize);
+  }
+  vertices.push_back(middle);
+
+  // plan final point if needed (to end position at rest).
+  if (above_safety) {
+    Eigen::Vector3d end_point_position = current_position_.translation();
+    end_point_position.z() = target_altitude;
+    end.makeStartOrEnd(end_point_position, derivative_to_optimize);
+    vertices.push_back(end);
+  }
+
+
+  // compute segment times
+  std::vector<double> segment_times;
+  segment_times = estimateSegmentTimes(vertices, max_v_, max_a_);
+
+
+  // compute segment times at mach slower speed / acceleration and use for
+  // first segment.
+  // a bit hacky....
+  std::vector<double> segment_times_slow;
+  segment_times_slow =
+      estimateSegmentTimes(vertices, max_v_ * 0.2, max_a_ * 0.2);
+  segment_times[0] = segment_times_slow[0];
+
+
+  // solve trajectory
+  const int N = 10;
+  mav_trajectory_generation::PolynomialOptimization<N> opt(dimension);
+  opt.setupFromVertices(vertices, segment_times, derivative_to_optimize);
+  opt.solveLinear();
+
+  // get trajectory
+  trajectory_.clear();
+  opt.getTrajectory(&trajectory_);
+
+  return true;
+}
+
+void ExamplePlanner::visualizeCachedTrajectory() {
+  visualization_msgs::MarkerArray markers;
+  double distance =
+      0.2; // Distance by which to seperate additional markers. Set 0.0 to disable.
+  std::string frame_id = "world";
+
+  mav_trajectory_generation::drawMavTrajectory(trajectory_,
+                                               distance,
+                                               frame_id,
+                                               &markers);
+  pub_markers_.publish(markers);
+}
+
+void ExamplePlanner::executeCachedTrajectory() {
+  mav_planning_msgs::PolynomialTrajectory4D msg;
+  mav_trajectory_generation::trajectoryToPolynomialTrajectoryMsg(trajectory_,
+                                                                 &msg);
+  msg.header.frame_id = "world";
+  pub_trajectory_.publish(msg);
+}

--- a/mav_trajectory_generation_example/src/example_planner_node.cc
+++ b/mav_trajectory_generation_example/src/example_planner_node.cc
@@ -1,0 +1,52 @@
+/*
+ * Simple example that shows a trajectory planner using
+ *  mav_trajectory_generation.
+ *
+ *
+ * Launch via
+ *   roslaunch mav_trajectory_generation_example example.launch
+ *
+ * Wait for console to run through all gazebo/rviz messages and then
+ * you should see the example below
+ *  - After Enter, it receives the current uav position
+ *  - After second enter, publishes trajectory information
+ *  - After third enter, executes trajectory (sends it to the sampler)
+ */
+
+#include  "ros/ros.h"
+#include <mav_trajectory_generation_example/example_planner.h>
+
+#include <iostream>
+
+int main(int argc, char** argv) {
+
+  ros::init(argc, argv, "simple_planner");
+
+  ros::NodeHandle n;
+  ExamplePlanner planner(n);
+  ROS_WARN_STREAM("SLEEPING FOR 5s TO WAIT FOR CLEAR CONSOLE");
+  ros::Duration(5.0).sleep();
+  ROS_WARN_STREAM("WARNING: CONSOLE INPUT/OUTPUT ONLY FOR DEMONSTRATION!");
+
+  // THIS SHOULD NORMALLY RUN INSIDE ROS::SPIN!!! JUST FOR DEMO PURPOSES LIKE THIS.
+  ROS_WARN_STREAM("PRESS ENTER TO UPDATE CURRENT POSITION");
+  std::cin.get();
+  for (int i = 0; i < 10; i++) {
+    ros::spinOnce();  // process a few messages in the background - causes the uavPoseCallback to happen
+  }
+  Eigen::Affine3d pose;
+  planner.getCurrentPose(&pose);
+  ROS_WARN_STREAM("CURRENT POSITION: " << pose.translation());
+
+  ROS_WARN_STREAM("PRESS ENTER TO VISUALIZE TRAJECTORY....");
+  std::cin.get();
+  planner.planTakeOffTrajectory(5.0);
+  planner.visualizeCachedTrajectory();
+
+  ROS_WARN_STREAM("SENT RVIZ MARKERS. PRESS ENTER TO EXECUTE.");
+  std::cin.get();
+  planner.executeCachedTrajectory();
+  ROS_WARN_STREAM("DONE. GOODBYE.");
+
+  return 0;
+}


### PR DESCRIPTION
Minimum viable example of a planner that runs in the console and uses mav_trajectory_generation.
Shows usage of trajectory sampler as well.

Readme from header file:
- Launch via   roslaunch mav_trajectory_generation_example example.launch
- Wait for console to run through all gazebo/rviz messages and then  you should see the example below
- After Enter, it receives the current uav position
- After second enter, publishes trajectory information
- After third enter, executes trajectory (sends it to the sampler)
![console](https://user-images.githubusercontent.com/1169724/56141048-59583280-5f9c-11e9-97f3-a851a168abd9.png)

Starts Gazebo, and RVIZ.
RVIZ trajectory visualization:
![rviz](https://user-images.githubusercontent.com/1169724/56141089-6c6b0280-5f9c-11e9-9712-ae7b424e35c5.png)

RQT node graph (for info - will not be launched):
![rqt](https://user-images.githubusercontent.com/1169724/56141107-75f46a80-5f9c-11e9-88c1-f917195c005f.png)

