### PR TITLE
Add missing 'yaml_cpp_catkin' dependency for rosinstall

### DIFF
--- a/install/mav_trajectory_generation_https.rosinstall
+++ b/install/mav_trajectory_generation_https.rosinstall
@@ -1,5 +1,6 @@
 - git: {local-name: eigen_catkin, uri: 'https://github.com/ethz-asl/eigen_catkin.git'}
 - git: {local-name: eigen_checks, uri: 'https://github.com/ethz-asl/eigen_checks.git'}
 - git: {local-name: glog_catkin, uri: 'https://github.com/ethz-asl/glog_catkin.git'}
+- git: {local-name: yaml_cpp_catkin, uri: 'https://github.com/ethz-asl/yaml_cpp_catkin.git'}
 - git: {local-name: mav_comm, uri: 'https://github.com/ethz-asl/mav_comm.git'}
 - git: {local-name: nlopt, uri: 'https://github.com/ethz-asl/nlopt.git'}

--- a/install/mav_trajectory_generation_ssh.rosinstall
+++ b/install/mav_trajectory_generation_ssh.rosinstall
@@ -1,5 +1,6 @@
 - git: {local-name: eigen_catkin, uri: 'git@github.com:ethz-asl/eigen_catkin.git'}
 - git: {local-name: eigen_checks, uri: 'git@github.com:ethz-asl/eigen_checks.git'}
 - git: {local-name: glog_catkin, uri: 'git@github.com:ethz-asl/glog_catkin.git'}
+- git: {local-name: yaml_cpp_catkin, uri: 'git@github.com:ethz-asl/yaml_cpp_catkin.git'}
 - git: {local-name: mav_comm, uri: 'git@github.com:ethz-asl/mav_comm.git'}
 - git: {local-name: nlopt, uri: 'git@github.com:ethz-asl/nlopt.git'}


### PR DESCRIPTION
When building the repository using `catkin build` the following error occurs: 
```
Errors     << mav_trajectory_generation:cmake /home/zieglert/catkin_ws/logs/mav_trajectory_generation/build.cmake.001.log                                                                                                                     
CMake Error at /home/zieglert/catkin_ws/devel/share/catkin_simple/cmake/catkin_simple-extras.cmake:38 (find_package):
  By not providing "Findyaml_cpp_catkin.cmake" in CMAKE_MODULE_PATH this
  project has asked CMake to find a package configuration file provided by
  "yaml_cpp_catkin", but CMake did not find one.

  Could not find a package configuration file provided by "yaml_cpp_catkin"
  with any of the following names:

    yaml_cpp_catkinConfig.cmake
    yaml_cpp_catkin-config.cmake

  Add the installation prefix of "yaml_cpp_catkin" to CMAKE_PREFIX_PATH or
  set "yaml_cpp_catkin_DIR" to a directory containing one of the above files.
  If "yaml_cpp_catkin" provides a separate development package or SDK, be
  sure it has been installed for the wstool.
  
```

See also https://github.com/ethz-asl/mav_trajectory_generation/issues/102


The error occurs due to the missing dependency `yaml_cpp_catkin`. This MR adds the missing dependency when installing rosinstall.