### PR TITLE
fix incorrect check on nlopt initial step size

### DIFF
--- a/mav_trajectory_generation/include/mav_trajectory_generation/impl/polynomial_optimization_nonlinear_impl.h
+++ b/mav_trajectory_generation/include/mav_trajectory_generation/impl/polynomial_optimization_nonlinear_impl.h
@@ -472,7 +472,7 @@ int PolynomialOptimizationNonLinear<_N>::optimizeTimeAndFreeConstraints() {
     double x = initial_solution[i];
     const double abs_x = std::abs(x);
     // Initial step size cannot be 0.0 --> invalid arg
-    if (abs_x <= std::numeric_limits<double>::lowest()) {
+    if (abs_x <= std::numeric_limits<double>::epsilon()) {
       initial_step.push_back(1e-13);
     } else {
       initial_step.push_back(optimization_parameters_.initial_stepsize_rel *


### PR DESCRIPTION
**Machine**: Ubuntu 18.04 / ROS Melodic

When using the example code (as outlined in README) with default waypoints, nlopt works fine. I changed the waypoints to `{ (0,0,1), (0,1,1), (0, 2, 1), (1,2,1) }` and get

```bash
E0523 22:24:15.674819 30226 polynomial_optimization_nonlinear_impl.h:505] error while setting up nlopt: nlopt invalid argument
```

I traced it back to the `nlopt_->set_initial_step(initial_step);` line and realized that the initial step size check was no good. Need to be using `epsilon` instead of `lowest`.

```
[ WARN] [1590287087.016327259]: lowest: -1.79769e+308
[ WARN] [1590287087.016402808]: epsilon: 2.22045e-16
```
