### PR TITLE
Fix/installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Michael Burri, Helen Oleynikova, Markus Achtelik, and Roland Siegwart, “**Real
 ## Installation Instructions (Ubuntu)
 To install this package with [ROS Indigo](http://wiki.ros.org/indigo/Installation/Ubuntu) or [ROS Kinetic](http://wiki.ros.org/kinetic/Installation/Ubuntu):
 
-1. Install additional system dependencies (swap indigo for kinetic as necessary):
+1. Install additional system dependencies (swap indigo for kinetic or melodic as necessary):
+
+** Note: ROS melodic requires libyaml-cpp-dev and does not build with yaml_cpp_catkin in your catkin workspace!
 
 ```
 sudo apt-get install python-wstool python-catkin-tools ros-indigo-cmake-modules libyaml-cpp-dev
@@ -64,7 +66,7 @@ wstool update
 wstool merge mav_trajectory_generation/install/mav_trajectory_generation_https.rosinstall
 wstool update -j8
 echo "source ~/catkin_ws/devel/setup.bash" >> ~/.bashrc
-source ~/.bashrc
+source /opt/ros/indigo/setup.bash
 ```
 
 In case you have your SSH keys for github set up, feel free to use the ssh rosinstall instead:

--- a/install/mav_trajectory_generation_https.rosinstall
+++ b/install/mav_trajectory_generation_https.rosinstall
@@ -1,3 +1,4 @@
+- git: {local-name: catkin_simple, uri: 'https://github.com/catkin/catkin_simple.git'}
 - git: {local-name: eigen_catkin, uri: 'https://github.com/ethz-asl/eigen_catkin.git'}
 - git: {local-name: eigen_checks, uri: 'https://github.com/ethz-asl/eigen_checks.git'}
 - git: {local-name: glog_catkin, uri: 'https://github.com/ethz-asl/glog_catkin.git'}

--- a/install/mav_trajectory_generation_ssh.rosinstall
+++ b/install/mav_trajectory_generation_ssh.rosinstall
@@ -1,3 +1,4 @@
+- git: {local-name: catkin_simple, uri: 'git@github.com:catkin/catkin_simple.git'}
 - git: {local-name: eigen_catkin, uri: 'git@github.com:ethz-asl/eigen_catkin.git'}
 - git: {local-name: eigen_checks, uri: 'git@github.com:ethz-asl/eigen_checks.git'}
 - git: {local-name: glog_catkin, uri: 'git@github.com:ethz-asl/glog_catkin.git'}

--- a/mav_trajectory_generation/package.xml
+++ b/mav_trajectory_generation/package.xml
@@ -19,9 +19,10 @@
 
   <depend>cmake_modules</depend>
   <depend>eigen_catkin</depend>
-  <depend>yaml_cpp_catkin</depend>
   <depend>eigen_checks</depend>
   <depend>glog_catkin</depend>
   <depend>mav_msgs</depend>
   <depend>nlopt</depend>
+
+  <exec_depend>yaml_cpp_catkin</exec_depend>
 </package>


### PR DESCRIPTION
- Add missing catkin_simple depeǹdency https://github.com/ethz-asl/mav_trajectory_generation/pull/106
- Sort out yaml_cpp_catkin dependency
  - If yaml_cpp_catkin exists in workspace, build it and use it (only works for ROS indigo and kinetic)
  - If yaml_cpp_catkin does not exist in workspace, try to use system yaml-cpp.
- Update installation instructions to guide users on yaml_cpp_catkin

This should resolve
https://github.com/ethz-asl/mav_trajectory_generation/pull/106
https://github.com/ethz-asl/mav_trajectory_generation/issues/79
https://github.com/ethz-asl/mav_trajectory_generation/issues/102

But longterm yaml_cpp_catkin dependency should be removed in favor of system yaml-cpp since on ROS melodic the current version of yaml_cpp_catkin creates problems. 

```
Errors     << mav_trajectory_generation:make /tmp/mav_ws/logs/mav_trajectory_generation/build.make.000.log                           
/tmp/mav_ws/devel/lib/libmav_trajectory_generation.so: undefined reference to `YAML::detail::node_data::push_back(YAML::detail::node&, boost::shared_ptr<YAML::detail::memory_holder>)'
/tmp/mav_ws/devel/lib/libmav_trajectory_generation.so: undefined reference to `YAML::detail::node_data::convert_to_map(boost::shared_ptr<YAML::detail::memory_holder>)'
collect2: error: ld returned 1 exit status
make[2]: *** [/tmp/mav_ws/devel/lib/mav_trajectory_generation/polynomial_timing_evaluation] Error 1
make[1]: *** [CMakeFiles/polynomial_timing_evaluation.dir/all] Error 2
make: *** [all] Error 2
```